### PR TITLE
Implement vendor order status updates and add tests

### DIFF
--- a/__tests__/vendor-dashboard.test.js
+++ b/__tests__/vendor-dashboard.test.js
@@ -17,13 +17,17 @@ jest.mock('../scripts/database.js', () => ({
 
 const dbModule = require('../scripts/database.js');
 
+const vendorDashboard = require('../scripts/vendor-dashboard.js');
+
 const {
   calculateRevenue,
   initVendorDashboard,
   getStatusButtons,
   renderOrders,
-  updateOrderStatus
-} = require('../scripts/vendor-dashboard.js');
+  updateOrderStatus,
+  fetchVendorOrders,
+  attachOrderStatusListeners
+} = vendorDashboard;
 
 describe('calculateRevenue', () => {
   test('sums order totals correctly', () => {
@@ -61,7 +65,7 @@ describe('getStatusButtons', () => {
   test('renders all three status buttons', () => {
     const html = getStatusButtons({
       id: 'order-1',
-      status: 'pending'
+      status: 'Pending'
     });
 
     expect(html).toContain('Pending');
@@ -119,12 +123,56 @@ describe('renderOrders', () => {
     expect(html).toContain('Total: R75');
   });
 
+  test('renders multiple orders correctly', () => {
+    renderOrders([
+      { id: '1', status: 'pending', total: 10 },
+      { id: '2', status: 'ready', total: 20 }
+    ]);
+
+    const html = document.getElementById('orders-list').innerHTML;
+
+    expect(html).toContain('Order #1');
+    expect(html).toContain('Order #2');
+  });
+
   test('does nothing if orders-list element does not exist', () => {
     document.body.innerHTML = '';
 
     expect(() => renderOrders([
       { id: 'x', status: 'pending', total: 20 }
     ])).not.toThrow();
+  });
+});
+
+describe('fetchVendorOrders', () => {
+  test('fetches and maps vendor orders correctly', async () => {
+    dbModule.collection.mockReturnValue('orders-ref');
+    dbModule.where.mockReturnValue('where-clause');
+    dbModule.query.mockReturnValue('orders-query');
+    dbModule.getDocs.mockResolvedValue({
+      docs: [
+        {
+          id: 'order-1',
+          data: () => ({ vendorId: 'vendor-1', total: 50, status: 'pending' })
+        },
+        {
+          id: 'order-2',
+          data: () => ({ vendorId: 'vendor-1', total: 75, status: 'ready' })
+        }
+      ]
+    });
+
+    const result = await fetchVendorOrders('vendor-1');
+
+    expect(dbModule.collection).toHaveBeenCalledWith(dbModule.db, 'orders');
+    expect(dbModule.where).toHaveBeenCalledWith('vendorId', '==', 'vendor-1');
+    expect(dbModule.query).toHaveBeenCalledWith('orders-ref', 'where-clause');
+    expect(dbModule.getDocs).toHaveBeenCalledWith('orders-query');
+
+    expect(result).toEqual([
+      { id: 'order-1', vendorId: 'vendor-1', total: 50, status: 'pending' },
+      { id: 'order-2', vendorId: 'vendor-1', total: 75, status: 'ready' }
+    ]);
   });
 });
 
@@ -140,6 +188,75 @@ describe('updateOrderStatus', () => {
   });
 });
 
+describe('attachOrderStatusListeners', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <section id="orders-list"></section>
+    `;
+  });
+
+  test('returns if orders-list does not exist', () => {
+    document.body.innerHTML = '';
+
+    expect(() => attachOrderStatusListeners()).not.toThrow();
+  });
+
+  test('attaches listener only once', () => {
+    attachOrderStatusListeners();
+    attachOrderStatusListeners();
+
+    const ordersList = document.getElementById('orders-list');
+    expect(ordersList.dataset.listenerAttached).toBe('true');
+  });
+
+  test('ignores clicks that are not on buttons', async () => {
+    const ordersList = document.getElementById('orders-list');
+    ordersList.innerHTML = `<article><p>No button here</p></article>`;
+
+    attachOrderStatusListeners();
+
+    ordersList.querySelector('p').click();
+
+    expect(dbModule.updateDoc).not.toHaveBeenCalled();
+  });
+
+  test('ignores button clicks with missing data attributes', async () => {
+    const ordersList = document.getElementById('orders-list');
+    ordersList.innerHTML = `<button type="button">Broken button</button>`;
+
+    attachOrderStatusListeners();
+
+    ordersList.querySelector('button').click();
+    await Promise.resolve();
+
+    expect(dbModule.updateDoc).not.toHaveBeenCalled();
+  });
+
+  test('updates firestore and ui when a valid status button is clicked', async () => {
+    dbModule.doc.mockReturnValue('order-ref');
+    dbModule.updateDoc.mockResolvedValue();
+
+    renderOrders([
+      { id: 'order-1', status: 'pending', total: 75 }
+    ]);
+
+    attachOrderStatusListeners();
+
+    const button = document.querySelector('[data-order-id="order-1"][data-status="Preparing"]');
+    button.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(dbModule.doc).toHaveBeenCalledWith(dbModule.db, 'orders', 'order-1');
+    expect(dbModule.updateDoc).toHaveBeenCalledWith('order-ref', { status: 'Preparing' });
+
+    const html = document.getElementById('orders-list').innerHTML;
+    expect(html).toContain('Status: Preparing');
+  });
+});
+
 describe('initVendorDashboard', () => {
   let mockLocation;
   let mockAlert;
@@ -152,12 +269,12 @@ describe('initVendorDashboard', () => {
 
     document.body.innerHTML = `
       <button id="logoutBtn"></button>
-      <div id="loading-state" class="hidden"></div>
-      <div id="empty-state" class="hidden"></div>
-      <div id="menu-table-wrapper" class="hidden"></div>
+      <section id="loading-state" class="hidden"></section>
+      <section id="empty-state" class="hidden"></section>
+      <section id="menu-table-wrapper" class="hidden"></section>
       <tbody id="menu-table-body"></tbody>
-      <div id="item-edit-modal" class="hidden"></div>
-      <div id="delete-modal" class="hidden"></div>
+      <section id="item-edit-modal" class="hidden"></section>
+      <section id="delete-modal" class="hidden"></section>
       <button id="confirm-delete-btn"></button>
       <form id="item-form"></form>
       <input id="edit-item-id" value="" />
@@ -170,7 +287,7 @@ describe('initVendorDashboard', () => {
       <span id="form-error" class="hidden"></span>
       <span id="save-btn-text">Save Item</span>
       <button id="save-btn"></button>
-      <div id="save-spinner" class="hidden"></div>
+      <section id="save-spinner" class="hidden"></section>
       <section id="orders-list"></section>
     `;
   });
@@ -226,6 +343,8 @@ describe('initVendorDashboard', () => {
       data: () => ({ role: 'vendor', status: 'pending' })
     });
 
+    dbModule.getDocs.mockResolvedValue({ docs: [] });
+
     initVendorDashboard(mockLocation, mockAlert);
     await Promise.resolve();
 
@@ -249,7 +368,7 @@ describe('initVendorDashboard', () => {
     expect(mockLocation.href).toBe('login.html');
   });
 
-  test('allows approved vendor', async () => {
+  test('allows approved vendor and renders orders', async () => {
     console.log = jest.fn();
 
     dbModule.onAuthStateChanged.mockImplementation((auth, callback) => {
@@ -262,13 +381,20 @@ describe('initVendorDashboard', () => {
     });
 
     dbModule.getDocs.mockResolvedValue({
-      docs: []
+      docs: [
+        {
+          id: 'order-1',
+          data: () => ({ vendorId: '123', total: 60, status: 'pending' })
+        }
+      ]
     });
 
     initVendorDashboard(mockLocation, mockAlert);
     await Promise.resolve();
     await Promise.resolve();
+    await Promise.resolve();
 
     expect(console.log).toHaveBeenCalledWith('Access granted to vendor dashboard');
+    expect(document.getElementById('orders-list').innerHTML).toContain('Order #order-1');
   });
 });

--- a/__tests__/vendor-dashboard.test.js
+++ b/__tests__/vendor-dashboard.test.js
@@ -15,32 +15,14 @@ jest.mock('../scripts/database.js', () => ({
   serverTimestamp: jest.fn(),
 }));
 
-// Stub every DOM element vendor-dashboard.js references at load time
-document.body.innerHTML = `
-  <button id="logoutBtn"></button>
-  <div id="loading-state" class="hidden"></div>
-  <div id="empty-state" class="hidden"></div>
-  <div id="menu-table-wrapper" class="hidden"></div>
-  <tbody id="menu-table-body"></tbody>
-  <div id="item-edit-modal" class="hidden"></div>
-  <div id="delete-modal" class="hidden"></div>
-  <button id="confirm-delete-btn"></button>
-  <form id="item-form"></form>
-  <input id="edit-item-id" value="" />
-  <input id="item-name" value="" />
-  <textarea id="item-description"></textarea>
-  <input id="item-price" value="" />
-  <select id="item-category"><option value="Mains">Mains</option></select>
-  <input type="checkbox" id="item-available" />
-  <span id="modal-title"></span>
-  <span id="form-error" class="hidden"></span>
-  <span id="save-btn-text">Save Item</span>
-  <button id="save-btn"></button>
-  <div id="save-spinner" class="hidden"></div>
-`;
+const dbModule = require('../scripts/database.js');
+
 const {
   calculateRevenue,
-  initVendorDashboard
+  initVendorDashboard,
+  getStatusButtons,
+  renderOrders,
+  updateOrderStatus
 } = require('../scripts/vendor-dashboard.js');
 
 describe('calculateRevenue', () => {
@@ -60,7 +42,7 @@ describe('calculateRevenue', () => {
   test('defaults missing total to 0', () => {
     const orders = [
       { total: 100 },
-      {},            // no total field
+      {},
       { total: 50 },
     ];
     expect(calculateRevenue(orders)).toBe(150);
@@ -75,21 +57,127 @@ describe('calculateRevenue', () => {
   });
 });
 
-const dbModule = require('../scripts/database.js');
+describe('getStatusButtons', () => {
+  test('renders all three status buttons', () => {
+    const html = getStatusButtons({
+      id: 'order-1',
+      status: 'pending'
+    });
+
+    expect(html).toContain('Pending');
+    expect(html).toContain('Preparing');
+    expect(html).toContain('Ready');
+    expect(html).toContain('data-order-id="order-1"');
+  });
+
+  test('disables the current status button', () => {
+    const html = getStatusButtons({
+      id: 'order-2',
+      status: 'Ready'
+    });
+
+    expect(html).toContain('data-status="Ready"');
+    expect(html).toContain('disabled');
+  });
+
+  test('defaults to pending when status is missing', () => {
+    const html = getStatusButtons({
+      id: 'order-3'
+    });
+
+    expect(html).toContain('data-status="Pending"');
+  });
+});
+
+describe('renderOrders', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <section id="orders-list"></section>
+    `;
+  });
+
+  test('shows empty message when there are no orders', () => {
+    renderOrders([]);
+
+    expect(document.getElementById('orders-list').innerHTML)
+      .toContain('No orders available yet.');
+  });
+
+  test('renders order details correctly', () => {
+    renderOrders([
+      {
+        id: 'Test order 1',
+        status: 'pending',
+        total: 75
+      }
+    ]);
+
+    const html = document.getElementById('orders-list').innerHTML;
+
+    expect(html).toContain('Order #Test order 1');
+    expect(html).toContain('Status: pending');
+    expect(html).toContain('Total: R75');
+  });
+
+  test('does nothing if orders-list element does not exist', () => {
+    document.body.innerHTML = '';
+
+    expect(() => renderOrders([
+      { id: 'x', status: 'pending', total: 20 }
+    ])).not.toThrow();
+  });
+});
+
+describe('updateOrderStatus', () => {
+  test('updates Firestore order status', async () => {
+    dbModule.doc.mockReturnValue('order-ref');
+    dbModule.updateDoc.mockResolvedValue();
+
+    await updateOrderStatus('order-1', 'ready');
+
+    expect(dbModule.doc).toHaveBeenCalledWith(dbModule.db, 'orders', 'order-1');
+    expect(dbModule.updateDoc).toHaveBeenCalledWith('order-ref', { status: 'ready' });
+  });
+});
 
 describe('initVendorDashboard', () => {
-
   let mockLocation;
   let mockAlert;
 
   beforeEach(() => {
     mockLocation = { href: '' };
     mockAlert = jest.fn();
+
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <button id="logoutBtn"></button>
+      <div id="loading-state" class="hidden"></div>
+      <div id="empty-state" class="hidden"></div>
+      <div id="menu-table-wrapper" class="hidden"></div>
+      <tbody id="menu-table-body"></tbody>
+      <div id="item-edit-modal" class="hidden"></div>
+      <div id="delete-modal" class="hidden"></div>
+      <button id="confirm-delete-btn"></button>
+      <form id="item-form"></form>
+      <input id="edit-item-id" value="" />
+      <input id="item-name" value="" />
+      <textarea id="item-description"></textarea>
+      <input id="item-price" value="" />
+      <select id="item-category"><option value="Mains">Mains</option></select>
+      <input type="checkbox" id="item-available" />
+      <span id="modal-title"></span>
+      <span id="form-error" class="hidden"></span>
+      <span id="save-btn-text">Save Item</span>
+      <button id="save-btn"></button>
+      <div id="save-spinner" class="hidden"></div>
+      <section id="orders-list"></section>
+    `;
   });
 
   test('redirects to login if no user', async () => {
     dbModule.onAuthStateChanged.mockImplementation((auth, callback) => {
-      callback(null); // no user
+      callback(null);
     });
 
     initVendorDashboard(mockLocation, mockAlert);
@@ -107,8 +195,6 @@ describe('initVendorDashboard', () => {
     });
 
     initVendorDashboard(mockLocation, mockAlert);
-
-    // wait for async
     await Promise.resolve();
 
     expect(mockLocation.href).toBe('login.html');
@@ -159,12 +245,12 @@ describe('initVendorDashboard', () => {
     initVendorDashboard(mockLocation, mockAlert);
     await Promise.resolve();
 
-    expect(mockAlert).toHaveBeenCalledWith("Your account is suspended");
+    expect(mockAlert).toHaveBeenCalledWith('Your account is suspended');
     expect(mockLocation.href).toBe('login.html');
   });
 
   test('allows approved vendor', async () => {
-    console.log = jest.fn(); // silence log
+    console.log = jest.fn();
 
     dbModule.onAuthStateChanged.mockImplementation((auth, callback) => {
       callback({ uid: '123' });
@@ -175,9 +261,14 @@ describe('initVendorDashboard', () => {
       data: () => ({ role: 'vendor', status: 'approved' })
     });
 
+    dbModule.getDocs.mockResolvedValue({
+      docs: []
+    });
+
     initVendorDashboard(mockLocation, mockAlert);
     await Promise.resolve();
+    await Promise.resolve();
 
-    expect(console.log).toHaveBeenCalledWith("Access granted to vendor dashboard");
+    expect(console.log).toHaveBeenCalledWith('Access granted to vendor dashboard');
   });
 });

--- a/scripts/vendor-dashboard.js
+++ b/scripts/vendor-dashboard.js
@@ -3,14 +3,18 @@ import {
   db,
   doc,
   getDoc,
-  onAuthStateChanged
+  getDocs,
+  updateDoc,
+  onAuthStateChanged,
+  collection,
+  query,
+  where
 } from "./database.js";
 
 // ---------------- AUTH GUARD ----------------
 export function initVendorDashboard(locationObj = window.location, alertFn = alert) {
   onAuthStateChanged(auth, async (user) => {
 
-    // ❌ Not logged in
     if (!user) {
       locationObj.href = "login.html";
       return;
@@ -26,27 +30,29 @@ export function initVendorDashboard(locationObj = window.location, alertFn = ale
 
     const userData = userSnap.data();
 
-    // ❌ Not a vendor
     if (userData.role !== "vendor") {
       locationObj.href = "index.html";
       return;
     }
 
-    // ❌ Pending vendor
     if (userData.status === "pending") {
       locationObj.href = "pending-approval.html";
       return;
     }
 
-    // ❌ Suspended vendor
     if (userData.status === "suspended") {
       alertFn("Your account is suspended");
       locationObj.href = "login.html";
       return;
     }
 
-    // ✅ Approved vendor
     console.log("Access granted to vendor dashboard");
+    console.log("Logged in vendor UID:", user.uid);
+
+
+    const orders = await fetchVendorOrders(user.uid);
+    renderOrders(orders);
+    attachOrderStatusListeners();
   });
 }
 
@@ -54,3 +60,122 @@ export function initVendorDashboard(locationObj = window.location, alertFn = ale
 export const calculateRevenue = (orders) => {
   return orders.reduce((sum, o) => sum + (o.total || 0), 0);
 };
+
+export async function fetchVendorOrders(vendorId) {
+  const ordersRef = collection(db, "orders");
+  const vendorOrdersQuery = query(ordersRef, where("vendorId", "==", vendorId));
+  const snapshot = await getDocs(vendorOrdersQuery);
+
+  return snapshot.docs.map((orderDoc) => ({
+    id: orderDoc.id,
+    ...orderDoc.data()
+  }));
+}
+
+export function getStatusButtons(order) {
+  const statuses = ["Pending", "Preparing", "Ready"];
+  const currentStatus = order.status || "Pending";
+
+  return statuses.map((status) => {
+    const isCurrent = currentStatus === status;
+
+    return `
+      <button
+        type="button"
+        class="px-3 py-1 rounded-lg border ${
+          isCurrent
+            ? "bg-indigo-600 text-white border-indigo-600"
+            : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+        }"
+        data-order-id="${order.id}"
+        data-status="${status}"
+        ${isCurrent ? "disabled" : ""}
+      >
+        ${status}
+      </button>
+    `;
+  }).join("");
+}
+
+export function renderOrders(orders) {
+  const ordersList = document.getElementById("orders-list");
+
+  if (!ordersList) {
+    return;
+  }
+
+  if (!orders.length) {
+    ordersList.innerHTML = `<p class="text-gray-500">No orders available yet.</p>`;
+    return;
+  }
+
+  ordersList.innerHTML = orders.map((order) => `
+    <article class="border border-gray-200 rounded-xl p-4">
+      <header class="mb-3">
+        <h3 class="text-lg font-semibold text-gray-900">Order #${order.id}</h3>
+        <p class="text-sm text-gray-600">Status: ${order.status || "pending"}</p>
+      </header>
+
+      <section class="mb-3">
+        <p class="text-sm text-gray-700">Total: R${order.total || 0}</p>
+      </section>
+
+      <section class="flex flex-wrap gap-2">
+        ${getStatusButtons(order)}
+      </section>
+    </article>
+  `).join("");
+}
+
+export async function updateOrderStatus(orderId, newStatus) {
+  const orderRef = doc(db, "orders", orderId);
+  await updateDoc(orderRef, { status: newStatus });
+}
+
+export function attachOrderStatusListeners() {
+  const ordersList = document.getElementById("orders-list");
+
+  if (!ordersList || ordersList.dataset.listenerAttached === "true") {
+    return;
+  }
+
+  ordersList.dataset.listenerAttached = "true";
+
+  ordersList.addEventListener("click", async (event) => {
+    const button = event.target.closest("button");
+
+    if (!button) {
+      return;
+    }
+
+    const orderId = button.dataset.orderId;
+    const newStatus = button.dataset.status;
+
+    if (!orderId || !newStatus) {
+      return;
+    }
+
+    await updateOrderStatus(orderId, newStatus);
+
+    const updatedOrderElement = button.closest("article");
+
+    if (!updatedOrderElement) {
+      return;
+    }
+
+    const statusText = updatedOrderElement.querySelector("p.text-sm.text-gray-600");
+
+    if (statusText) {
+      statusText.textContent = `Status: ${newStatus}`;
+    }
+
+    const buttonSection = updatedOrderElement.querySelector("section.flex.flex-wrap.gap-2");
+
+    if (buttonSection) {
+      buttonSection.innerHTML = getStatusButtons({
+        id: orderId,
+        status: newStatus
+      });
+    }
+  });
+}

--- a/vendor-dashboard.html
+++ b/vendor-dashboard.html
@@ -22,7 +22,6 @@
         <a href="menu-management.html" class="text-gray-700 hover:text-indigo-600">Menu</a>
       </section>
       <a href="login.html" class="text-gray-700 hover:text-indigo-600">Log Out</a>
-
     </section>
   </nav>
 
@@ -46,7 +45,6 @@
         <button data-tab="orders" class="tab-btn text-indigo-600 font-semibold hover:underline">
           Manage Orders
         </button>
-
       </article>
 
       <article class="bg-white rounded-2xl shadow-md p-6">
@@ -59,10 +57,7 @@
         </p>
         <a href="menu-management.html" class="inline-block text-indigo-600 font-semibold hover:underline">
           Update Menu
-        </button>
-
-  
-
+        </a>
       </article>
 
       <article class="bg-white rounded-2xl shadow-md p-6">
@@ -74,11 +69,9 @@
           Track sales and see how you are performing.
         </p>
         <button data-tab="sales" class="tab-btn text-indigo-600 font-semibold hover:underline">
-            View Analytics
+          View Analytics
         </button>
-
       </article>
-
     </section>
 
     <section class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
@@ -87,6 +80,9 @@
           <h2 class="text-2xl font-bold text-gray-900">Today’s Orders</h2>
         </header>
 
+        <section id="orders-list" class="space-y-4">
+          <p class="text-gray-500">No orders available yet.</p>
+        </section>
       </section>
 
       <section class="bg-white rounded-2xl shadow-md p-6">
@@ -109,17 +105,17 @@
     </section>
   </main>
 
-<script type="module">
-  import { initAuthUI, logout } from "./scripts/auth.js";
+  <script type="module">
+    import { initAuthUI, logout } from "./scripts/auth.js";
 
-  initAuthUI();
-  lucide.createIcons();
-  // Attach logout button
-  document.getElementById("logoutBtn")?.addEventListener("click", logout);
-</script>
-<script type="module">
-  import { initVendorDashboard } from "./scripts/vendor-dashboard.js";
-  initVendorDashboard();
-</script>
+    initAuthUI();
+    lucide.createIcons();
+    document.getElementById("logoutBtn")?.addEventListener("click", logout);
+  </script>
+
+  <script type="module">
+    import { initVendorDashboard } from "./scripts/vendor-dashboard.js";
+    initVendorDashboard();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This PR implements vendor order status updates.
 Vendors can now view their orders and update status (Pending, Preparing, Ready), with changes saved to Firestore and reflected in the UI. 
Firestore queries filter orders by vendor ID, and security rules were updated to restrict access so vendors can only modify their own orders. 
Jest tests were added/updated for `vendor-dashboard.js` to improve coverage, and all tests are passing.