### PR TITLE
Implement forgot password feature and password visibility toggle

### DIFF
--- a/__tests__/forgot-password.test.js
+++ b/__tests__/forgot-password.test.js
@@ -1,0 +1,60 @@
+// __tests__/forgot-password.test.js
+
+jest.mock('../scripts/database.js', () => ({
+  auth: {},
+  sendPasswordResetEmail: jest.fn()
+}));
+
+describe('forgot-password.js', () => {
+  let sendPasswordResetEmail;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <form id="forgotPasswordForm">
+        <input type="email" id="resetEmail" value="user@example.com" />
+        <button type="submit">Send</button>
+      </form>
+    `;
+
+    global.alert = jest.fn();
+    global.console.error = jest.fn();
+  });
+
+  test('successful password reset flow', async () => {
+    ({ sendPasswordResetEmail } = await import('../scripts/database.js'));
+    sendPasswordResetEmail.mockResolvedValue();
+
+    await import('../scripts/forgot-password.js');
+
+    const form = document.getElementById('forgotPasswordForm');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith({}, 'user@example.com');
+    expect(global.alert).toHaveBeenCalledWith(
+      'If an account exists for this email, a password reset link has been set.'
+    );
+  });
+
+  test('handles password reset error', async () => {
+    ({ sendPasswordResetEmail } = await import('../scripts/database.js'));
+    sendPasswordResetEmail.mockRejectedValue(new Error('User not found'));
+
+    await import('../scripts/forgot-password.js');
+
+    const form = document.getElementById('forgotPasswordForm');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith({}, 'user@example.com');
+    expect(global.console.error).toHaveBeenCalled();
+    expect(global.alert).toHaveBeenCalledWith('User not found');
+  });
+});

--- a/__tests__/login.test.js
+++ b/__tests__/login.test.js
@@ -1,6 +1,6 @@
 // __tests__/login.test.js
 
-import { navigateTo, redirectUser } from '../scripts/login.js';
+import { navigateTo, redirectUser, initPasswordToggle } from '../scripts/login.js';
 
 describe('navigateTo', () => {
   test('calls location.assign with the given page', () => {
@@ -19,6 +19,12 @@ describe('navigateTo', () => {
   test('throws error if invalid location object is passed', () => {
     expect(() => navigateTo('page.html', {})).toThrow('Invalid location object');
   });
+
+  test('navigateTo preserves exact page string', () => {
+  const mockAssign = jest.fn();
+  navigateTo('admin-dashboard.html', { assign: mockAssign });
+  expect(mockAssign).toHaveBeenCalledWith('admin-dashboard.html');
+});
 });
 
 describe('redirectUser', () => {
@@ -65,9 +71,57 @@ test('redirectUser does nothing for empty role', () => {
   expect(mockAssign).not.toHaveBeenCalled();
 });
 
-test('navigateTo preserves exact page string', () => {
-  const mockAssign = jest.fn();
-  navigateTo('admin-dashboard.html', { assign: mockAssign });
-  expect(mockAssign).toHaveBeenCalledWith('admin-dashboard.html');
 });
+describe('initPasswordToggle', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input type="password" id="loginPassword" />
+      <button type="button" id="toggleLoginPassword"></button>
+    `;
+
+    global.lucide = {
+      createIcons: jest.fn()
+    };
+  });
+
+  test('toggles password visibility from password to text', () => {
+    const passwordInput = document.getElementById('loginPassword');
+    const toggleButton = document.getElementById('toggleLoginPassword');
+
+    initPasswordToggle();
+
+    expect(passwordInput.type).toBe('password');
+
+    toggleButton.click();
+
+    expect(passwordInput.type).toBe('text');
+  });
+
+  test('toggles password visibility back from text to password', () => {
+    const passwordInput = document.getElementById('loginPassword');
+    const toggleButton = document.getElementById('toggleLoginPassword');
+
+    initPasswordToggle();
+
+    toggleButton.click();
+    toggleButton.click();
+
+    expect(passwordInput.type).toBe('password');
+  });
+
+  test('does not throw if password input is missing', () => {
+    document.body.innerHTML = `
+      <button type="button" id="toggleLoginPassword"></button>
+    `;
+
+    expect(() => initPasswordToggle()).not.toThrow();
+  });
+
+  test('does not throw if toggle button is missing', () => {
+    document.body.innerHTML = `
+      <input type="password" id="loginPassword" />
+    `;
+
+    expect(() => initPasswordToggle()).not.toThrow();
+  });
 });

--- a/__tests__/login.test.js
+++ b/__tests__/login.test.js
@@ -1,14 +1,42 @@
 // __tests__/login.test.js
 
-import { navigateTo, redirectUser, initPasswordToggle } from '../scripts/login.js';
+jest.mock('../scripts/database.js', () => ({
+  auth: {},
+  db: {},
+  signInWithEmailAndPassword: jest.fn(),
+  getDoc: jest.fn(),
+  doc: jest.fn(),
+  signInWithPopup: jest.fn(),
+  GoogleAuthProvider: jest.fn(() => ({ provider: 'google' })),
+  FacebookAuthProvider: jest.fn(() => ({ provider: 'facebook' })),
+  TwitterAuthProvider: jest.fn(() => ({ provider: 'twitter' })),
+  OAuthProvider: jest.fn((name) => ({ provider: name }))
+}));
+
+import {
+  navigateTo,
+  redirectUser,
+  initPasswordToggle,
+  initLoginForm,
+  initSocialLogins,
+  initLoginPage
+} from '../scripts/login.js';
+
+import {
+  signInWithEmailAndPassword,
+  getDoc,
+  doc,
+  signInWithPopup,
+  GoogleAuthProvider,
+  FacebookAuthProvider,
+  TwitterAuthProvider,
+  OAuthProvider
+} from '../scripts/database.js';
 
 describe('navigateTo', () => {
   test('calls location.assign with the given page', () => {
     const mockAssign = jest.fn();
-
-    const mockLocation = {
-      assign: mockAssign
-    };
+    const mockLocation = { assign: mockAssign };
 
     navigateTo('some-page.html', mockLocation);
 
@@ -20,11 +48,13 @@ describe('navigateTo', () => {
     expect(() => navigateTo('page.html', {})).toThrow('Invalid location object');
   });
 
-  test('navigateTo preserves exact page string', () => {
-  const mockAssign = jest.fn();
-  navigateTo('admin-dashboard.html', { assign: mockAssign });
-  expect(mockAssign).toHaveBeenCalledWith('admin-dashboard.html');
-});
+  test('preserves exact page string', () => {
+    const mockAssign = jest.fn();
+
+    navigateTo('admin-dashboard.html', { assign: mockAssign });
+
+    expect(mockAssign).toHaveBeenCalledWith('admin-dashboard.html');
+  });
 });
 
 describe('redirectUser', () => {
@@ -56,22 +86,21 @@ describe('redirectUser', () => {
     expect(mockAssign).not.toHaveBeenCalled();
   });
 
+  test('does nothing for null role', () => {
+    redirectUser(null, mockLocation);
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  test('does nothing for empty role', () => {
+    redirectUser('', mockLocation);
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
   test('throws error if invalid location object is passed', () => {
     expect(() => redirectUser('customer', {})).toThrow('Invalid location object');
   });
-  test('redirectUser does nothing for null role', () => {
-  const mockAssign = jest.fn();
-  redirectUser(null, { assign: mockAssign });
-  expect(mockAssign).not.toHaveBeenCalled();
 });
 
-test('redirectUser does nothing for empty role', () => {
-  const mockAssign = jest.fn();
-  redirectUser('', { assign: mockAssign });
-  expect(mockAssign).not.toHaveBeenCalled();
-});
-
-});
 describe('initPasswordToggle', () => {
   beforeEach(() => {
     document.body.innerHTML = `
@@ -84,14 +113,15 @@ describe('initPasswordToggle', () => {
     };
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('toggles password visibility from password to text', () => {
     const passwordInput = document.getElementById('loginPassword');
     const toggleButton = document.getElementById('toggleLoginPassword');
 
     initPasswordToggle();
-
-    expect(passwordInput.type).toBe('password');
-
     toggleButton.click();
 
     expect(passwordInput.type).toBe('text');
@@ -102,11 +132,20 @@ describe('initPasswordToggle', () => {
     const toggleButton = document.getElementById('toggleLoginPassword');
 
     initPasswordToggle();
-
     toggleButton.click();
     toggleButton.click();
 
     expect(passwordInput.type).toBe('password');
+  });
+
+  test('updates icon and calls lucide.createIcons when toggled', () => {
+    const toggleButton = document.getElementById('toggleLoginPassword');
+
+    initPasswordToggle();
+    toggleButton.click();
+
+    expect(toggleButton.innerHTML).toContain('eye-off');
+    expect(global.lucide.createIcons).toHaveBeenCalled();
   });
 
   test('does not throw if password input is missing', () => {
@@ -123,5 +162,167 @@ describe('initPasswordToggle', () => {
     `;
 
     expect(() => initPasswordToggle()).not.toThrow();
+  });
+});
+
+describe('initLoginForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input type="email" id="loginEmail" value="test@example.com" />
+        <input type="password" id="loginPassword" value="123456" />
+      </form>
+    `;
+
+    global.alert = jest.fn();
+  });
+
+  test('does nothing if login form is missing', () => {
+    document.body.innerHTML = `<section>No form here</section>`;
+
+    expect(() => initLoginForm()).not.toThrow();
+  });
+
+  test('submits login and reads user profile', async () => {
+    signInWithEmailAndPassword.mockResolvedValue({
+      user: { uid: 'abc123' }
+    });
+
+    doc.mockReturnValue({ id: 'mock-doc-ref' });
+
+    getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ role: 'customer' })
+    });
+
+    initLoginForm();
+
+    const form = document.getElementById('loginForm');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith({}, 'test@example.com', '123456');
+    expect(doc).toHaveBeenCalled();
+    expect(getDoc).toHaveBeenCalled();
+    expect(global.alert).not.toHaveBeenCalled();
+  });
+
+  test('alerts if user profile does not exist', async () => {
+    signInWithEmailAndPassword.mockResolvedValue({
+      user: { uid: 'abc123' }
+    });
+
+    doc.mockReturnValue({ id: 'mock-doc-ref' });
+
+    getDoc.mockResolvedValue({
+      exists: () => false
+    });
+
+    initLoginForm();
+
+    const form = document.getElementById('loginForm');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(global.alert).toHaveBeenCalledWith('User profile not found.');
+  });
+
+  test('alerts when login fails', async () => {
+    signInWithEmailAndPassword.mockRejectedValue(new Error('Invalid credentials'));
+
+    initLoginForm();
+
+    const form = document.getElementById('loginForm');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(global.alert).toHaveBeenCalledWith('Invalid credentials');
+  });
+});
+
+describe('initSocialLogins', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <button type="button" id="googleLogin"></button>
+      <button type="button" id="facebookLogin"></button>
+      <button type="button" id="twitterLogin"></button>
+      <button type="button" id="microsoftLogin"></button>
+      <button type="button" id="appleLogin"></button>
+    `;
+
+    global.alert = jest.fn();
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: {
+        setItem: jest.fn()
+      },
+      writable: true
+    });
+  });
+
+  test('sets up all providers', () => {
+    initSocialLogins();
+
+    expect(GoogleAuthProvider).toHaveBeenCalled();
+    expect(FacebookAuthProvider).toHaveBeenCalled();
+    expect(TwitterAuthProvider).toHaveBeenCalled();
+    expect(OAuthProvider).toHaveBeenCalledWith('microsoft.com');
+    expect(OAuthProvider).toHaveBeenCalledWith('apple.com');
+  });
+
+  test('alerts when social sign-in fails', async () => {
+    signInWithPopup.mockRejectedValue(new Error('Popup blocked'));
+
+    initSocialLogins();
+    document.getElementById('googleLogin').click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(global.alert).toHaveBeenCalledWith(
+      expect.stringContaining('googleLogin sign-in failed: Popup blocked')
+    );
+  });
+});
+
+describe('initLoginPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input type="email" id="loginEmail" value="user@test.com" />
+        <input type="password" id="loginPassword" value="pass123" />
+        <button type="submit">Sign In</button>
+      </form>
+
+      <button type="button" id="toggleLoginPassword"></button>
+
+      <button type="button" id="googleLogin"></button>
+      <button type="button" id="facebookLogin"></button>
+      <button type="button" id="twitterLogin"></button>
+      <button type="button" id="microsoftLogin"></button>
+      <button type="button" id="appleLogin"></button>
+    `;
+
+    global.lucide = {
+      createIcons: jest.fn()
+    };
+  });
+
+  test('initializes page helpers and creates icons', () => {
+    initLoginPage();
+
+    expect(global.lucide.createIcons).toHaveBeenCalled();
   });
 });

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CampusBites - Forgot Password</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="min-h-screen bg-gray-100">
+
+  <section class="relative min-h-screen">
+    <section class="absolute inset-0">
+      <img src="assets/Matrix.jpg" alt="Campus food court background" class="w-full h-full object-cover" />
+    </section>
+
+    <section class="absolute inset-0 bg-black/65"></section>
+
+    <section class="relative z-10 min-h-screen">
+      <nav class="bg-white/95 border-b border-gray-200 shadow-sm">
+        <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center h-16">
+          <header class="flex items-center gap-2">
+            <i data-lucide="utensils" class="w-7 h-7 text-indigo-600"></i>
+            <span class="text-xl font-bold text-gray-900">CampusBites</span>
+          </header>
+
+          <section class="flex items-center gap-6">
+            <a href="index.html" class="text-gray-700 hover:text-indigo-600">Home</a>
+            <a href="login.html" class="text-gray-700 hover:text-indigo-600">Login</a>
+          </section>
+        </section>
+      </nav>
+
+      <section class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-10">
+        <main class="bg-white p-8 rounded-xl shadow-md w-full max-w-md">
+          <header>
+            <h1 class="text-2xl font-bold mb-6 text-center">Forgot Password</h1>
+          </header>
+
+          <section aria-labelledby="forgot-password-title">
+            <h2 id="forgot-password-title" class="sr-only">Forgot password form</h2>
+
+            <form id="forgotPasswordForm" class="space-y-4">
+              <label for="resetEmail" class="block font-medium">Email</label>
+              <section class="relative">
+                <i data-lucide="mail" class="absolute left-3 top-3 h-5 w-5 text-gray-400"></i>
+                <input
+                  type="email"
+                  id="resetEmail"
+                  name="email"
+                  class="w-full pl-10 pr-3 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                  placeholder="Enter your email"
+                  required
+                />
+              </section>
+
+              <button
+                type="submit"
+                class="w-full bg-indigo-600 text-white py-2 rounded-lg hover:bg-indigo-700 transition"
+              >
+                Send Reset Link
+              </button>
+            </form>
+          </section>
+
+          <footer>
+            <p class="mt-4 text-center text-sm text-gray-600">
+              <a href="login.html" class="text-indigo-600 font-semibold hover:underline">
+                Back to Login
+              </a>
+            </p>
+          </footer>
+        </main>
+      </section>
+    </section>
+  </section>
+
+  <script type="module" src="scripts/forgot-password.js"></script>
+  <script>
+    lucide.createIcons();
+  </script>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -65,7 +65,22 @@
                 placeholder="Enter your password"
                 required
               />
+
+              <button
+                type="button"
+                id="toggleLoginPassword"
+                class="absolute right-3 top-3 text-gray-400 hover:text-gray-600"
+                aria-label="Toggle password visibility"
+              >
+                <i data-lucide="eye" class="h-5 w-5"></i>
+              </button>
               </section>
+
+              <section class="text-right">
+                <a href="forgot-password.html" class="text-sm text-indigo-600 hover:underline">
+                  Forgot Password?
+                </a>
+            </section>
 
               <button
                 type="submit"

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -10,7 +10,8 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   onAuthStateChanged,
-  signOut
+  signOut,
+  sendPasswordResetEmail
 } from "https://www.gstatic.com/firebasejs/12.11.0/firebase-auth.js";
 
 import {
@@ -75,7 +76,8 @@ export {
   query,
   where,
   serverTimestamp,
-  signOut
+  signOut,
+  sendPasswordResetEmail
 };
 
 /*export class MenuItem{

--- a/scripts/forgot-password.js
+++ b/scripts/forgot-password.js
@@ -1,0 +1,21 @@
+import {
+  auth,
+  sendPasswordResetEmail
+} from "./database.js";
+
+const form = document.getElementById("forgotPasswordForm");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+
+  const email = document.getElementById("resetEmail").value;
+
+  try {
+    await sendPasswordResetEmail(auth, email);
+    alert("If an account exists for this email, a password reset link has been set.");
+    window.location.href = "login.html";
+  } catch (error) {
+    console.error("Password reset error:", error);
+    alert(error.message);
+  }
+});

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -95,10 +95,32 @@ async function handleSocialLogin(user) {
   redirectUser(userSnap.data().role);
 }
 
+// ---------------- PASSWORD TOGGLE ----------------
+export function initPasswordToggle() {
+  const passwordInput = document.getElementById("loginPassword");
+  const toggleButton = document.getElementById("toggleLoginPassword");
+
+  if (!passwordInput || !toggleButton) return;
+
+  toggleButton.addEventListener("click", () => {
+    const isHidden = passwordInput.type === "password";
+
+    passwordInput.type = isHidden ? "text" : "password";
+
+    toggleButton.innerHTML = isHidden
+      ? '<i data-lucide="eye-off" class="h-5 w-5"></i>'
+      : '<i data-lucide="eye" class="h-5 w-5"></i>';
+
+    if (typeof lucide !== "undefined") {
+      lucide.createIcons();
+    }
+  });
+}
 // ---------------- INIT (SAFE FOR BROWSER ONLY) ----------------
 export function initLoginPage() {
   initLoginForm();
   initSocialLogins();
+  initPasswordToggle();
 
   if (typeof lucide !== 'undefined') {
     lucide.createIcons();


### PR DESCRIPTION
Closes #44 

This PR implements the forgot password functionality using Firebase Authentication and improves login usability with a password visibility toggle

Changes made:
- Added "Forgot Password?" link to the login page
- Created forgot-password.html with email input form
- Implemented password reset logic using sendPasswordResetEmail
- Added neutral confirmation messaging to prevent email enumeration
- Handled error cases for invalid email format and request failures
- Added password visibility toggle to the login form
- Tested the password reset flow and password visibility behavior

Testing Notes:
- All existing tests pass successfully after implementing changes
- Added tests for password visibility toggle
- Automated tests for the forgot password feature have not yet been implemented!

This improves both account recovery and login usability

Files changed
- login.html
- scripts/login.js
- scripts/database.js
- __tests__/login.test.js

Files added
- forgot-password.html
- scripts/forgot-password.js