### PR TITLE
feat: add admin moderation for menu items (approval, suspension, and reviews)

### DIFF
--- a/__tests__/admin-menuManagement.test.js
+++ b/__tests__/admin-menuManagement.test.js
@@ -1,0 +1,334 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+jest.mock("../scripts/database.js", () => ({
+  auth: {
+    signOut: jest.fn(() => Promise.resolve())
+  },
+  db: {},
+  onAuthStateChanged: jest.fn(),
+  getDoc: jest.fn(),
+  getDocs: jest.fn(),
+  updateDoc: jest.fn(),
+  doc: jest.fn((db, collectionName, id) => ({
+    collectionName,
+    id,
+    path: `${collectionName}/${id}`
+  })),
+  collection: jest.fn((db, collectionName) => collectionName)
+}));
+
+describe("admin-menuManagement.js", () => {
+  let database;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    document.body.innerHTML = `
+      <a id="loginLink"></a>
+      <button id="logoutBtn" class="hidden"></button>
+
+      <table>
+        <tbody id="vendor-table-body"></tbody>
+      </table>
+
+      <section id="details-modal" class="hidden"></section>
+    `;
+
+    global.lucide = {
+      createIcons: jest.fn()
+    };
+
+    global.alert = jest.fn();
+    global.prompt = jest.fn();
+
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    database = await import("../scripts/database.js");
+
+    database.auth.signOut.mockResolvedValue();
+
+    database.onAuthStateChanged.mockImplementation((auth, callback) => {
+      callback({ uid: "admin123" });
+    });
+
+    database.getDoc.mockImplementation(async (ref) => {
+      if (ref.collectionName === "users" && ref.id === "admin123") {
+        return {
+          exists: () => true,
+          data: () => ({
+            role: "admin",
+            fullName: "Admin User"
+          })
+        };
+      }
+
+      if (ref.collectionName === "users" && ref.id === "vendor123") {
+        return {
+          exists: () => true,
+          data: () => ({
+            role: "vendor",
+            shopName: "Campus Café"
+          })
+        };
+      }
+
+      return {
+        exists: () => false,
+        data: () => ({})
+      };
+    });
+
+    database.getDocs.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: "item123",
+          data: () => ({
+            vendorId: "vendor123",
+            vendorName: "Campus Café",
+            name: "Chicken Burger",
+            description: "Fresh grilled chicken burger",
+            price: 45,
+            category: "Main Course",
+            image: "burger.jpg",
+            status: "pending",
+            reviewReason: "",
+            available: true,
+            allergens: ["Gluten"],
+            dietary: ["Halal"],
+            calories: 500,
+            protein: 25,
+            carbs: 40
+          })
+        }
+      ]
+    });
+
+    database.updateDoc.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  test("loads menu items for an admin user", async () => {
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(database.getDocs).toHaveBeenCalledTimes(1);
+    expect(document.body.innerHTML).toContain("Campus Café");
+    expect(document.body.innerHTML).toContain("Chicken Burger");
+    expect(document.body.innerHTML).toContain("pending");
+  });
+
+  test("approves a menu item", async () => {
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    const approveBtn = document.querySelector(".approve-btn");
+    expect(approveBtn).not.toBeNull();
+
+    approveBtn.click();
+
+    await flush();
+
+    expect(database.updateDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "menu_items",
+        id: "item123"
+      }),
+      {
+        status: "approved",
+        reviewReason: ""
+      }
+    );
+
+    expect(alert).toHaveBeenCalledWith("Menu item approved successfully.");
+  });
+
+  test("suspends a menu item with review reason", async () => {
+    prompt.mockReturnValue("Image is unclear.");
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    const suspendBtn = document.querySelector(".suspend-btn");
+    expect(suspendBtn).not.toBeNull();
+
+    suspendBtn.click();
+
+    await flush();
+
+    expect(database.updateDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "menu_items",
+        id: "item123"
+      }),
+      {
+        status: "suspended",
+        reviewReason: "Image is unclear."
+      }
+    );
+
+    expect(alert).toHaveBeenCalledWith("Menu item suspended successfully.");
+  });
+
+  test("does not suspend item without review reason", async () => {
+    prompt.mockReturnValue("");
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    const suspendBtn = document.querySelector(".suspend-btn");
+    expect(suspendBtn).not.toBeNull();
+
+    suspendBtn.click();
+
+    await flush();
+
+    expect(database.updateDoc).not.toHaveBeenCalled();
+    expect(alert).toHaveBeenCalledWith("Suspension reason is required.");
+  });
+
+  test("opens item details modal when item name is clicked", async () => {
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    const detailsBtn = document.querySelector(".item-details-btn");
+    expect(detailsBtn).not.toBeNull();
+
+    detailsBtn.click();
+
+    const modalHtml = document.getElementById("details-modal").innerHTML;
+
+    expect(modalHtml).toContain("Chicken Burger");
+    expect(modalHtml).toContain("Fresh grilled chicken burger");
+    expect(modalHtml).toContain("Gluten");
+    expect(modalHtml).toContain("Halal");
+    expect(modalHtml).toContain("Admin Review");
+  });
+
+  test("closes item details modal", async () => {
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    document.querySelector(".item-details-btn").click();
+
+    const closeBtn = document.getElementById("closeDetailsModal");
+    expect(closeBtn).not.toBeNull();
+
+    closeBtn.click();
+
+    const modal = document.getElementById("details-modal");
+
+    expect(modal.classList.contains("hidden")).toBe(true);
+    expect(modal.innerHTML).toBe("");
+  });
+
+  test("shows empty message when there are no menu items", async () => {
+    database.getDocs.mockResolvedValueOnce({
+      empty: true,
+      docs: []
+    });
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(document.body.innerHTML).toContain("No menu items found.");
+  });
+
+  test("shows error message when menu items fail to load", async () => {
+    database.getDocs.mockRejectedValueOnce(new Error("Firestore failed"));
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(document.body.innerHTML).toContain("Failed to load menu items.");
+  });
+
+  test("blocks non-admin users", async () => {
+    database.getDoc.mockImplementation(async (ref) => {
+      if (ref.collectionName === "users" && ref.id === "admin123") {
+        return {
+          exists: () => true,
+          data: () => ({
+            role: "vendor"
+          })
+        };
+      }
+
+      return {
+        exists: () => false,
+        data: () => ({})
+      };
+    });
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(alert).toHaveBeenCalledWith("Access denied. Admins only.");
+  });
+
+  test("does not load menu items when user is not logged in", async () => {
+    database.onAuthStateChanged.mockImplementation((auth, callback) => {
+      callback(null);
+    });
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(database.getDocs).not.toHaveBeenCalled();
+  });
+
+  test("does not load menu items when admin document does not exist", async () => {
+    database.getDoc.mockResolvedValueOnce({
+      exists: () => false,
+      data: () => ({})
+    });
+
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    expect(database.getDocs).not.toHaveBeenCalled();
+  });
+
+  test("logs out user", async () => {
+    await import("../scripts/admin-menuManagement.js");
+
+    await flush();
+    await flush();
+
+    document.getElementById("logoutBtn").click();
+
+    await flush();
+
+    expect(database.auth.signOut).toHaveBeenCalled();
+  });
+});

--- a/__tests__/admin-menuManagement.test.js
+++ b/__tests__/admin-menuManagement.test.js
@@ -331,4 +331,50 @@ describe("admin-menuManagement.js", () => {
 
     expect(database.auth.signOut).toHaveBeenCalled();
   });
+test("handles unknown vendor", async () => {
+  database.getDoc.mockImplementation(async (ref) => {
+    if (ref.collectionName === "users" && ref.id === "admin123") {
+      return {
+        exists: () => true,
+        data: () => ({
+          role: "admin",
+          fullName: "Admin User"
+        })
+      };
+    }
+
+    if (ref.collectionName === "users" && ref.id === "vendor123") {
+      return {
+        exists: () => false,
+        data: () => ({})
+      };
+    }
+
+    return {
+      exists: () => false,
+      data: () => ({})
+    };
+  });
+
+  await import("../scripts/admin-menuManagement.js");
+
+  await flush();
+  await flush();
+
+  expect(document.body.innerHTML).toContain("Unknown Vendor");
+});
+test("handles approve failure", async () => {
+  database.updateDoc.mockRejectedValueOnce(new Error("fail"));
+
+  await import("../scripts/admin-menuManagement.js");
+
+  await flush();
+  await flush();
+
+  document.querySelector(".approve-btn").click();
+
+  await flush();
+
+  expect(alert).toHaveBeenCalledWith("Failed to approve menu item.");
+});
 });

--- a/__tests__/admin-menuManagement.test.js
+++ b/__tests__/admin-menuManagement.test.js
@@ -377,4 +377,58 @@ test("handles approve failure", async () => {
 
   expect(alert).toHaveBeenCalledWith("Failed to approve menu item.");
 });
+test("handles vendor fetch error gracefully", async () => {
+  database.getDoc.mockImplementation(async (ref) => {
+    if (ref.collectionName === "users" && ref.id === "admin123") {
+      return {
+        exists: () => true,
+        data: () => ({ role: "admin" })
+      };
+    }
+
+    if (ref.collectionName === "users" && ref.id === "vendor123") {
+      throw new Error("Firestore failed");
+    }
+
+    return { exists: () => false };
+  });
+
+  await import("../scripts/admin-menuManagement.js");
+
+  await flush();
+  await flush();
+
+  expect(document.body.innerHTML).toContain("Unknown Vendor");
+});
+test("handles logout failure", async () => {
+  database.auth.signOut.mockRejectedValueOnce(new Error("logout failed"));
+
+  await import("../scripts/admin-menuManagement.js");
+
+  await flush();
+  await flush();
+
+  document.getElementById("logoutBtn").click();
+
+  await flush();
+
+  expect(console.error).toHaveBeenCalledWith(
+    "Logout failed:",
+    expect.any(Error)
+  );
+});
+test("rejects suspend when reason is only spaces", async () => {
+  prompt.mockReturnValue("   ");
+
+  await import("../scripts/admin-menuManagement.js");
+
+  await flush();
+  await flush();
+
+  document.querySelector(".suspend-btn").click();
+
+  await flush();
+
+  expect(alert).toHaveBeenCalledWith("Suspension reason is required.");
+});
 });

--- a/__tests__/browse.test.js
+++ b/__tests__/browse.test.js
@@ -627,4 +627,35 @@ describe("browse.js", () => {
     expect(cart[0].name).toBe("Burger");
     expect(document.getElementById("details-modal").classList.contains("hidden")).toBe(true);
   });
+  test("handles items with no dietary or allergens", async () => {
+  mockBrowseQueries(db, [
+    {
+      id: "10",
+      name: "Simple Food",
+      vendorId: "vendor-1",
+      price: 20,
+      available: true,
+      status: "approved"
+    }
+  ]);
+
+  const mod = await import("../scripts/browse.js");
+  await mod.loadBrowseItems();
+
+  expect(document.getElementById("menu").innerHTML)
+    .toContain("Simple Food");
+});
+test("modal close button does nothing if missing", async () => {
+  mockBrowseQueries(db);
+
+  const mod = await import("../scripts/browse.js");
+  await mod.loadBrowseItems();
+
+  document.getElementById("details-modal").innerHTML = "";
+
+  // should not crash
+  expect(() => {
+    document.getElementById("closeDetailsModal")?.click();
+  }).not.toThrow();
+});
 });

--- a/__tests__/browse.test.js
+++ b/__tests__/browse.test.js
@@ -9,7 +9,7 @@ jest.mock("../scripts/database.js", () => ({
   db: {},
   getDocs: jest.fn(),
   addDoc: jest.fn(),
-  collection: jest.fn((...args) => args),
+  collection: jest.fn((db, collectionName) => collectionName),
   onAuthStateChanged: jest.fn()
 }));
 
@@ -23,6 +23,7 @@ const sampleItems = [
     description: "Tasty",
     category: "Mains",
     available: true,
+    status: "approved",
     dietary: ["Vegan"],
     allergens: []
   },
@@ -35,6 +36,7 @@ const sampleItems = [
     description: "Cheesy",
     category: "Mains",
     available: true,
+    status: "approved",
     dietary: [],
     allergens: ["Gluten"]
   },
@@ -47,6 +49,7 @@ const sampleItems = [
     description: "Fresh",
     category: "Sides",
     available: false,
+    status: "approved",
     dietary: ["Vegetarian"],
     allergens: []
   },
@@ -59,15 +62,47 @@ const sampleItems = [
     description: "Halal wrap",
     category: "Wraps",
     available: true,
+    status: "approved",
     dietary: ["Halal"],
+    allergens: []
+  },
+  {
+    id: "6",
+    name: "Rejected Item",
+    vendorName: "Shop1",
+    vendorId: "vendor-1",
+    price: 25,
+    description: "Should not show",
+    category: "Mains",
+    available: true,
+    status: "suspended",
+    dietary: [],
     allergens: []
   }
 ];
 
 const approvedVendors = [
-  { id: "vendor-1", role: "vendor", status: "approved", shopName: "Shop1" },
-  { id: "vendor-2", role: "vendor", status: "approved", shopName: "Shop2" },
-  { id: "vendor-3", role: "vendor", status: "approved", shopName: "Shop3" }
+  {
+    id: "vendor-1",
+    role: "vendor",
+    status: "approved",
+    shopName: "Shop1",
+    location: "Matrix"
+  },
+  {
+    id: "vendor-2",
+    role: "vendor",
+    status: "approved",
+    shopName: "Shop2",
+    location: "Library Lawns"
+  },
+  {
+    id: "vendor-3",
+    role: "vendor",
+    status: "approved",
+    shopName: "Shop3",
+    location: "Great Hall"
+  }
 ];
 
 const makeSnapshot = (items) => ({
@@ -81,15 +116,23 @@ const makeSnapshot = (items) => ({
 });
 
 const mockBrowseQueries = (db, items = sampleItems, vendors = approvedVendors) => {
-  db.getDocs
-    .mockResolvedValueOnce(makeSnapshot(items))
-    .mockResolvedValueOnce(makeSnapshot(vendors));
+  db.getDocs.mockImplementation(async (collectionName) => {
+    if (collectionName === "menu_items") {
+      return makeSnapshot(items);
+    }
+
+    if (collectionName === "users") {
+      return makeSnapshot(vendors);
+    }
+
+    return makeSnapshot([]);
+  });
 };
 
 const flush = async () => {
   await Promise.resolve();
   await Promise.resolve();
-  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
 describe("browse.js", () => {
@@ -101,17 +144,12 @@ describe("browse.js", () => {
     jest.resetModules();
 
     document.body.innerHTML = `
-      <a id="AdmindashboardLink"></a>
-      <a id="CustomerdashboardLink"></a>
-      <a id="VendordashboardLink"></a>
-      <a id="loginLink"></a>
-
       <select id="Vendors">
-        <option value="AllVendors">AllVendors</option>
+        <option value="AllVendors">All Vendors</option>
       </select>
 
       <select id="Categories">
-        <option value="AllCategories">AllCategories</option>
+        <option value="AllCategories">All Categories</option>
         <option value="Mains">Mains</option>
         <option value="Sides">Sides</option>
         <option value="Wraps">Wraps</option>
@@ -125,6 +163,7 @@ describe("browse.js", () => {
       <button id="cart"></button>
       <p id="numItems"></p>
       <p id="numItemsCart"></p>
+      <span id="cartCount"></span>
       <section id="cartWarning" class="hidden"></section>
       <section id="PriceFilter"></section>
 
@@ -135,7 +174,7 @@ describe("browse.js", () => {
       <section id="details-modal" class="hidden"></section>
 
       <button id="closeCartModal"></button>
-      <button id="checkOut">Check Out</button>
+      <button id="checkOut">Pay Now</button>
     `;
 
     localStorage.clear();
@@ -144,15 +183,16 @@ describe("browse.js", () => {
 
     alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
     errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    delete global.fetch;
   });
 
-  test("renders available items only", async () => {
+  test("renders available and approved items only", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
@@ -163,24 +203,21 @@ describe("browse.js", () => {
     expect(html).toContain("Pizza");
     expect(html).toContain("Wrap");
     expect(html).not.toContain("Salad");
+    expect(html).not.toContain("Rejected Item");
   });
 
   test("updates count text", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
 
-    expect(document.getElementById("numItems").textContent)
-      .toBe("3 items found");
+    expect(document.getElementById("numItems").textContent).toBe("3 items found");
   });
 
   test("adds item to cart and opens cart modal", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
@@ -188,96 +225,78 @@ describe("browse.js", () => {
     document.querySelector(".add-cart-btn").click();
     document.getElementById("cart").click();
 
-    expect(
-      document.getElementById("item-edit-modal")
-        .classList.contains("hidden")
-    ).toBe(false);
-
-    expect(document.getElementById("cartList").innerHTML)
-      .toContain("Burger");
-
-    expect(document.getElementById("numItemsCart").textContent)
-      .toBe("1 item in cart");
+    expect(document.getElementById("item-edit-modal").classList.contains("hidden")).toBe(false);
+    expect(document.getElementById("cartList").innerHTML).toContain("Burger");
+    expect(document.getElementById("numItemsCart").textContent).toBe("1 item in cart");
   });
 
   test("removes item from cart", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
 
     document.querySelector(".add-cart-btn").click();
     document.getElementById("cart").click();
-
     document.querySelector(".remove-cart-btn").click();
 
-    expect(document.getElementById("cartList").innerHTML)
-      .not.toContain("Burger");
+    expect(document.getElementById("cartList").innerHTML).not.toContain("Burger");
   });
 
   test("shows warning when cart empty", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
 
     document.getElementById("checkOut").click();
 
-    expect(
-      document.getElementById("cartWarning")
-        .classList.contains("hidden")
-    ).toBe(false);
+    expect(document.getElementById("cartWarning").classList.contains("hidden")).toBe(false);
   });
 
   test("alerts when user not logged in", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
 
     document.getElementById("checkOut").click();
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      "You must be logged in to proceed to checkout"
-    );
+    expect(alertSpy).toHaveBeenCalledWith("You must be logged in to proceed to checkout");
   });
 
-  test("posts cart items to PayFast and submits the returned form", async () => {
+  test("posts cart items to PayFast and submits returned form", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
-    const fetchMock = jest.fn().mockResolvedValue({
+    global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         action: "https://sandbox.payfast.co.za/eng/process",
-        fields: { merchant_id: "10000100", amount: "130.00", signature: "abc" }
+        fields: {
+          merchant_id: "10000100",
+          amount: "130.00",
+          signature: "abc"
+        }
       })
     });
-    global.fetch = fetchMock;
 
-    const submitSpy = jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => {});
+    const submitSpy = jest
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => {});
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
+
     document.querySelector('.add-cart-btn[data-item-id="1"]').click();
     document.querySelector('.add-cart-btn[data-item-id="2"]').click();
-
     document.getElementById("checkOut").click();
 
     await flush();
-    await flush();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(global.fetch).toHaveBeenCalledWith(
       "/api/payfast/create-payment",
       expect.objectContaining({
         method: "POST",
@@ -289,20 +308,9 @@ describe("browse.js", () => {
       })
     );
 
-    const form = document.querySelector(
-      'form[action="https://sandbox.payfast.co.za/eng/process"]'
-    );
-    expect(form).toBeTruthy();
-    expect(form.method.toUpperCase()).toBe("POST");
-    expect(form.querySelector('input[name="merchant_id"]').value).toBe("10000100");
-    expect(form.querySelector('input[name="amount"]').value).toBe("130.00");
-    expect(form.querySelector('input[name="signature"]').value).toBe("abc");
-
-    expect(submitSpy).toHaveBeenCalledTimes(1);
-
+    expect(document.querySelector('form[action="https://sandbox.payfast.co.za/eng/process"]')).toBeTruthy();
+    expect(submitSpy).toHaveBeenCalled();
     expect(JSON.parse(localStorage.getItem("cart") || "[]")).toEqual([]);
-
-    delete global.fetch;
   });
 
   test("sends all cart entries to PayFast even when items share a vendor", async () => {
@@ -319,46 +327,36 @@ describe("browse.js", () => {
           description: "Crispy",
           category: "Sides",
           available: true,
+          status: "approved",
           dietary: [],
           allergens: []
         }
       ],
-      [
-        {
-          id: "vendor-1",
-          role: "vendor",
-          status: "approved",
-          shopName: "Shop1"
-        }
-      ]
+      [approvedVendors[0]]
     );
 
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
-    const fetchMock = jest.fn().mockResolvedValue({
+    global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         action: "https://sandbox.payfast.co.za/eng/process",
-        fields: { merchant_id: "10000100", amount: "70.00", signature: "abc" }
+        fields: { merchant_id: "10000100" }
       })
     });
-    global.fetch = fetchMock;
 
     jest.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(() => {});
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
+
     document.querySelector('.add-cart-btn[data-item-id="1"]').click();
     document.querySelector('.add-cart-btn[data-item-id="5"]').click();
-
     document.getElementById("checkOut").click();
 
     await flush();
-    await flush();
 
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(global.fetch).toHaveBeenCalledWith(
       "/api/payfast/create-payment",
       expect.objectContaining({
         body: JSON.stringify({
@@ -367,17 +365,11 @@ describe("browse.js", () => {
         })
       })
     );
-
-    delete global.fetch;
   });
 
-  test("handles addDoc failure", async () => {
+  test("handles PayFast failure", async () => {
     mockBrowseQueries(db);
-    db.addDoc.mockRejectedValue(new Error("Firestore failed"));
-
-    db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-      cb({ uid: "customer-1" })
-    );
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
@@ -392,32 +384,19 @@ describe("browse.js", () => {
     document.getElementById("checkOut").click();
 
     await flush();
-    await flush();
 
     expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("boom"));
     expect(document.getElementById("checkOut").disabled).toBe(false);
-
-    delete global.fetch;
   });
 
   test("filters by vendor", async () => {
     mockBrowseQueries(db);
-    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
 
     const mod = await import("../scripts/browse.js");
     await mod.loadBrowseItems();
 
-    document.getElementById("Vendors").innerHTML = `
-      <option value="AllVendors">AllVendors</option>
-      <option value="Shop1">Shop1</option>
-    `;
-
     document.getElementById("Vendors").value = "Shop1";
-
-    mockBrowseQueries(db);
-
-    document.getElementById("Vendors")
-      .dispatchEvent(new Event("change"));
+    document.getElementById("Vendors").dispatchEvent(new Event("change"));
 
     await flush();
 
@@ -427,272 +406,225 @@ describe("browse.js", () => {
     expect(html).not.toContain("Pizza");
     expect(html).not.toContain("Wrap");
   });
+
   test("renders empty cart message when cart is opened with no items", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    mockBrowseQueries(db);
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  document.getElementById("cart").click();
+    document.getElementById("cart").click();
 
-  expect(document.getElementById("cartList").innerHTML)
-    .toContain("Your cart is empty.");
+    expect(document.getElementById("cartList").innerHTML).toContain("Your cart is empty.");
+    expect(document.getElementById("numItemsCart").textContent).toBe("0 items in cart");
+  });
 
-  expect(document.getElementById("numItemsCart").textContent)
-    .toBe("0 items in cart");
-});
+  test("closes cart modal when close button is clicked", async () => {
+    mockBrowseQueries(db);
 
-test("closes cart modal when close button is clicked", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    document.getElementById("cart").click();
+    document.getElementById("closeCartModal").click();
 
-  document.getElementById("cart").click();
-  document.getElementById("closeCartModal").click();
+    expect(document.getElementById("item-edit-modal").classList.contains("hidden")).toBe(true);
+  });
 
-  expect(
-    document.getElementById("item-edit-modal").classList.contains("hidden")
-  ).toBe(true);
-});
+  test("filters vegan items", async () => {
+    mockBrowseQueries(db);
 
-test("filters vegan items", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    document.getElementById("Vegan").checked = true;
+    document.getElementById("Vegan").dispatchEvent(new Event("click"));
 
-  document.getElementById("Vegan").checked = true;
+    await flush();
 
-  mockBrowseQueries(db);
+    const html = document.getElementById("menu").innerHTML;
 
-  document.getElementById("Vegan")
-    .dispatchEvent(new Event("click"));
+    expect(html).toContain("Burger");
+    expect(html).not.toContain("Pizza");
+    expect(html).not.toContain("Wrap");
+  });
 
-  await flush();
+  test("filters halal items", async () => {
+    mockBrowseQueries(db);
 
-  const html = document.getElementById("menu").innerHTML;
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  expect(html).toContain("Burger");
-  expect(html).not.toContain("Pizza");
-  expect(html).not.toContain("Wrap");
-});
+    document.getElementById("Halal").checked = true;
+    document.getElementById("Halal").dispatchEvent(new Event("click"));
 
-test("filters halal items", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    await flush();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    const html = document.getElementById("menu").innerHTML;
 
-  document.getElementById("Halal").checked = true;
+    expect(html).toContain("Wrap");
+    expect(html).not.toContain("Burger");
+    expect(html).not.toContain("Pizza");
+  });
 
-  mockBrowseQueries(db);
+  test("filters gluten-free items", async () => {
+    mockBrowseQueries(db);
 
-  document.getElementById("Halal")
-    .dispatchEvent(new Event("click"));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  await flush();
+    document.getElementById("Gluten-Free").checked = true;
+    document.getElementById("Gluten-Free").dispatchEvent(new Event("click"));
 
-  const html = document.getElementById("menu").innerHTML;
+    await flush();
 
-  expect(html).toContain("Wrap");
-  expect(html).not.toContain("Burger");
-  expect(html).not.toContain("Pizza");
-});
+    const html = document.getElementById("menu").innerHTML;
 
-test("filters gluten-free items", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    expect(html).toContain("Burger");
+    expect(html).toContain("Wrap");
+    expect(html).not.toContain("Pizza");
+  });
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+  test("filters by category", async () => {
+    mockBrowseQueries(db);
 
-  document.getElementById("Gluten-Free").checked = true;
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  mockBrowseQueries(db);
+    document.getElementById("Categories").value = "Wraps";
+    document.getElementById("Categories").dispatchEvent(new Event("change"));
 
-  document.getElementById("Gluten-Free")
-    .dispatchEvent(new Event("click"));
+    await flush();
 
-  await flush();
+    const html = document.getElementById("menu").innerHTML;
 
-  const html = document.getElementById("menu").innerHTML;
+    expect(html).toContain("Wrap");
+    expect(html).not.toContain("Burger");
+    expect(html).not.toContain("Pizza");
+  });
 
-  expect(html).toContain("Burger");
-  expect(html).toContain("Wrap");
-  expect(html).not.toContain("Pizza");
-});
+  test("price slider filters items by max price", async () => {
+    mockBrowseQueries(db);
 
-test("filters by category", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    const slider = document.getElementById("PriceSlider");
 
-  document.getElementById("Categories").value = "Wraps";
+    expect(slider).not.toBeNull();
 
-  mockBrowseQueries(db);
+    slider.value = "40";
+    slider.dispatchEvent(new Event("click", { bubbles: true }));
 
-  document.getElementById("Categories")
-    .dispatchEvent(new Event("change"));
+    await flush();
 
-  await flush();
+    const html = document.getElementById("menu").innerHTML;
 
-  const html = document.getElementById("menu").innerHTML;
+    expect(html).not.toContain("Burger");
+    expect(html).not.toContain("Pizza");
+    expect(html).not.toContain("Wrap");
+  });
 
-  expect(html).toContain("Wrap");
-  expect(html).not.toContain("Burger");
-  expect(html).not.toContain("Pizza");
-});
-test("price slider filters items by max price", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+  test("remove cart ignores invalid index", async () => {
+    mockBrowseQueries(db);
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "user-1" }));
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const slider = document.getElementById("PriceSlider");
+    document.querySelector(".add-cart-btn").click();
+    document.getElementById("cart").click();
 
-  expect(slider).not.toBeNull();
+    const btn = document.createElement("button");
+    btn.className = "remove-cart-btn";
+    btn.dataset.cartIndex = "invalid";
 
-  slider.value = "40";
+    document.getElementById("cartList").appendChild(btn);
+    btn.click();
 
-  mockBrowseQueries(db);
+    expect(document.getElementById("cartList").innerHTML).toContain("Burger");
+  });
 
-  slider.dispatchEvent(new Event("click", { bubbles: true }));
+  test("opens item details modal when Details button is clicked", async () => {
+    mockBrowseQueries(db);
 
-  await flush();
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  expect(document.getElementById("PriceLabel").textContent)
-    .toContain("Max Price: 40");
+    document.querySelector(".item-details-btn").click();
 
-  const html = document.getElementById("menu").innerHTML;
+    const modal = document.getElementById("details-modal");
 
-  expect(html).not.toContain("Burger");
-  expect(html).not.toContain("Pizza");
-  expect(html).not.toContain("Wrap");
-});
+    expect(modal.classList.contains("hidden")).toBe(false);
+    expect(modal.innerHTML).toContain("Burger");
+  });
 
-test("remove cart ignores invalid index", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-    cb({ uid: "user-1" })
-  );
+  test("renders vendor location in item details modal", async () => {
+    mockBrowseQueries(db, [sampleItems[0]], [approvedVendors[0]]);
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  document.querySelector(".add-cart-btn").click();
-  document.getElementById("cart").click();
+    document.querySelector(".item-details-btn").click();
 
-  const btn = document.createElement("button");
-  btn.className = "remove-cart-btn";
-  btn.dataset.cartIndex = "invalid";
+    expect(document.getElementById("details-modal").innerHTML).toContain("Matrix");
+  });
 
-  document.getElementById("cartList").appendChild(btn);
-  btn.click();
+  test("renders nutritional info in modal", async () => {
+    mockBrowseQueries(
+      db,
+      [
+        {
+          ...sampleItems[0],
+          calories: 500,
+          protein: 20,
+          carbs: 60
+        }
+      ],
+      approvedVendors
+    );
 
-  expect(document.getElementById("cartList").innerHTML).toContain("Burger");
-});
-test("opens item details modal when Details button is clicked", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    document.querySelector(".item-details-btn").click();
 
-  // click Details button
-  document.querySelector(".item-details-btn").click();
+    const html = document.getElementById("details-modal").innerHTML;
 
-  const modal = document.getElementById("details-modal");
+    expect(html).toContain("500");
+    expect(html).toContain("20");
+    expect(html).toContain("60");
+  });
 
-  expect(modal.classList.contains("hidden")).toBe(false);
-  expect(modal.innerHTML).toContain("Burger");
-});
-test("renders vendor location in item details modal", async () => {
-  mockBrowseQueries(db, sampleItems, [
-    {
-      id: "vendor-1",
-      role: "vendor",
-      status: "approved",
-      shopName: "Shop1",
-      location: "Matrix"
-    }
-  ]);
+  test("closes item details modal when close button is clicked", async () => {
+    mockBrowseQueries(db);
 
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+    document.querySelector(".item-details-btn").click();
 
-  document.querySelector(".item-details-btn").click();
+    expect(document.getElementById("details-modal").classList.contains("hidden")).toBe(false);
 
-  expect(document.getElementById("details-modal").innerHTML)
-    .toContain("Matrix");
-});
-test("renders nutritional info in modal", async () => {
-  mockBrowseQueries(db, [
-    {
-      ...sampleItems[0],
-      calories: 500,
-      protein: 20,
-      carbs: 60
-    }
-  ], approvedVendors);
+    document.getElementById("closeDetailsModal").click();
 
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    expect(document.getElementById("details-modal").classList.contains("hidden")).toBe(true);
+  });
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
+  test("adds item to cart from details modal", async () => {
+    mockBrowseQueries(db);
+    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "customer-1" }));
 
-  document.querySelector(".item-details-btn").click();
+    const mod = await import("../scripts/browse.js");
+    await mod.loadBrowseItems();
 
-  const html = document.getElementById("details-modal").innerHTML;
+    document.querySelector(".item-details-btn").click();
+    document.getElementById("detailsAddToCart").click();
 
-  expect(html).toContain("500");
-  expect(html).toContain("20");
-  expect(html).toContain("60");
-});
-test("closes item details modal when close button is clicked", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb(null));
+    const cart = JSON.parse(localStorage.getItem("cart") || "[]");
 
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
-
-  document.querySelector(".item-details-btn").click();
-
-  expect(document.getElementById("details-modal").classList.contains("hidden"))
-    .toBe(false);
-
-  document.getElementById("closeDetailsModal").click();
-
-  expect(document.getElementById("details-modal").classList.contains("hidden"))
-    .toBe(true);
-});
-test("adds item to cart from details modal", async () => {
-  mockBrowseQueries(db);
-  db.onAuthStateChanged.mockImplementation((_auth, cb) =>
-    cb({ uid: "customer-1" })
-  );
-
-  const mod = await import("../scripts/browse.js");
-  await mod.loadBrowseItems();
-
-  document.querySelector(".item-details-btn").click();
-  document.getElementById("detailsAddToCart").click();
-
-  const cart = JSON.parse(localStorage.getItem("cart") || "[]");
-
-  expect(cart).toHaveLength(1);
-  expect(cart[0].name).toBe("Burger");
-  expect(document.getElementById("details-modal").classList.contains("hidden"))
-    .toBe(true);
-});
-
+    expect(cart).toHaveLength(1);
+    expect(cart[0].name).toBe("Burger");
+    expect(document.getElementById("details-modal").classList.contains("hidden")).toBe(true);
+  });
 });

--- a/__tests__/menuManagement.test.js
+++ b/__tests__/menuManagement.test.js
@@ -1,80 +1,116 @@
 /**
  * @jest-environment jsdom
  */
+
 global.lucide = { createIcons: jest.fn() };
 
-jest.mock('../scripts/database.js', () => ({
+jest.mock("../scripts/database.js", () => ({
   db: {},
   auth: {
     onAuthStateChanged: jest.fn()
   },
-
   addDoc: jest.fn(),
   getDocs: jest.fn(),
   getDoc: jest.fn(),
   updateDoc: jest.fn(),
   deleteDoc: jest.fn(),
-
   collection: jest.fn(() => "collectionRef"),
   where: jest.fn(() => "whereClause"),
   query: jest.fn(() => "queryRef"),
   doc: jest.fn(() => "docRef"),
-
   serverTimestamp: jest.fn(() => "timestamp"),
-
   storage: {},
-  ref: jest.fn(),
+  ref: jest.fn(() => "storageRef"),
   uploadBytes: jest.fn(),
   getDownloadURL: jest.fn()
 }));
 
-describe("menu.js", () => {
-  let auth, getDocs, getDoc, addDoc, updateDoc, deleteDoc, uploadBytes, getDownloadURL;
+const flush = () => new Promise((resolve) => setTimeout(resolve, 50));
 
- beforeEach(() => {
-  jest.resetModules();
-  jest.clearAllMocks();
+describe("menuManagement.js", () => {
+  let auth;
+  let getDocs;
+  let getDoc;
+  let addDoc;
+  let updateDoc;
+  let deleteDoc;
+  let uploadBytes;
+  let getDownloadURL;
 
-  document.body.innerHTML = `
-    <table>
-      <tbody id="menu-table-body"></tbody>
-    </table>
-
-    <form id="item-form"></form>
-    <input id="edit-item-id" />
-    <input id="item-name" />
-    <input id="item-description" />
-    <input id="item-price" />
-    <input id="item-category" />
-    <input id="item-image" type="file" />
-
-    <div id="item-edit-modal" class="hidden"></div>
-    <h2 id="modal-title"></h2>
-
-    <button id="add-item-btn"></button>
-
-    <input type="checkbox" class="item-allergen" value="nuts" />
-    <input type="checkbox" class="item-dietary" value="vegan" />
-  `;
-
-  document.getElementById("item-form").reset = jest.fn();
-  ({ auth, getDocs, getDoc, addDoc, updateDoc, deleteDoc, uploadBytes, getDownloadURL } =
-  require('../scripts/database.js'));
-  auth.onAuthStateChanged.mockImplementation(cb => cb({ uid: "user123" }));
-
-  getDoc.mockResolvedValue({
-    data: () => ({ shopName: "Test Shop" })
-  });
-});
   const loadModule = async () => {
-  await import('../scripts/menuManagement.js');
-  await new Promise(r => setTimeout(r, 50));
-};
-  // tests...
-   test("initialises and loads menu items", async () => {
+    await import("../scripts/menuManagement.js");
+    await flush();
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    document.body.innerHTML = `
+      <table>
+        <tbody id="menu-table-body"></tbody>
+      </table>
+
+      <form id="item-form"></form>
+      <input id="edit-item-id" />
+      <input id="item-name" />
+      <input id="item-description" />
+      <input id="item-price" />
+      <input id="item-category" />
+      <input id="item-calories" />
+      <input id="item-protein" />
+      <input id="item-carbs" />
+      <input id="item-image" type="file" />
+
+      <div id="item-edit-modal" class="hidden"></div>
+      <h2 id="modal-title"></h2>
+
+      <button id="add-item-btn"></button>
+
+      <input type="checkbox" class="item-allergen" value="nuts" />
+      <input type="checkbox" class="item-dietary" value="vegan" />
+    `;
+
+    document.getElementById("item-form").reset = jest.fn();
+
+    ({
+      auth,
+      getDocs,
+      getDoc,
+      addDoc,
+      updateDoc,
+      deleteDoc,
+      uploadBytes,
+      getDownloadURL
+    } = require("../scripts/database.js"));
+
+    auth.onAuthStateChanged.mockImplementation((callback) => {
+      callback({ uid: "user123" });
+    });
+
+    getDoc.mockResolvedValue({
+      data: () => ({
+        shopName: "Test Shop",
+        role: "vendor",
+        status: "approved"
+      })
+    });
+
     getDocs.mockResolvedValue({ docs: [] });
 
+    global.alert = jest.fn();
+    global.confirm = jest.fn(() => true);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("initialises and loads menu items", async () => {
     await loadModule();
+
     expect(getDocs).toHaveBeenCalled();
   });
 
@@ -88,52 +124,74 @@ describe("menu.js", () => {
             category: "Fast Food",
             price: 50,
             available: true,
-            image: "img.jpg"
+            image: "img.jpg",
+            status: "approved",
+            reviewReason: ""
           })
         }
       ]
     });
 
     await loadModule();
-    await new Promise(r => setTimeout(r, 100));
+
     const tbody = document.getElementById("menu-table-body");
+
     expect(tbody.innerHTML).toContain("Burger");
     expect(tbody.innerHTML).toContain("Fast Food");
     expect(tbody.innerHTML).toContain("R50");
+    expect(tbody.innerHTML).toContain("approved");
+  });
+
+  test("shows suspended item status and admin review reason", async () => {
+    getDocs.mockResolvedValue({
+      docs: [
+        {
+          id: "item123",
+          data: () => ({
+            name: "Burger",
+            image: "burger.jpg",
+            category: "Main Course",
+            price: 45,
+            available: true,
+            status: "suspended",
+            reviewReason: "Image is unclear"
+          })
+        }
+      ]
+    });
+
+    await loadModule();
+
+    const html = document.getElementById("menu-table-body").innerHTML;
+
+    expect(html).toContain("suspended");
+    expect(html).toContain("Admin review: Image is unclear");
   });
 
   test("deleteItem deletes and refreshes", async () => {
-    global.confirm = jest.fn(() => true);
-
-    getDocs.mockResolvedValue({
-      docs: [
-        {
-          id: "1",
-          data: () => ({ name: "Burger" })
-        }
-      ]
-    });
-
     await loadModule();
+
     await window.views.deleteItem("123");
 
-    expect(deleteDoc).toHaveBeenCalled();
+    expect(deleteDoc).toHaveBeenCalledWith("docRef");
+  });
+
+  test("deleteItem does nothing when confirm is cancelled", async () => {
+    global.confirm = jest.fn(() => false);
+
+    await loadModule();
+
+    await window.views.deleteItem("123");
+
+    expect(deleteDoc).not.toHaveBeenCalled();
   });
 
   test("toggleAvailability updates item", async () => {
-    getDocs.mockResolvedValue({
-      docs: [
-        {
-          id: "1",
-          data: () => ({ name: "Burger" })
-        }
-      ]
-    });
-
     await loadModule();
+
     await window.views.toggleAvailability("123", true);
 
-    expect(updateDoc).toHaveBeenCalledWith(expect.anything(), {
+    expect(updateDoc).toHaveBeenCalledWith("docRef", {
       available: false
     });
   });
@@ -148,23 +206,188 @@ describe("menu.js", () => {
             description: "Nice",
             price: 50,
             category: "Fast Food",
-            allergens: [],
-            dietary: []
+            allergens: ["nuts"],
+            dietary: ["vegan"],
+            calories: 500,
+            protein: 20,
+            carbs: 45
           })
         }
       ]
     });
 
     await loadModule();
+
     await window.views.openEditItem("1");
 
     expect(document.getElementById("item-name").value).toBe("Burger");
-    expect(document.getElementById("modal-title").textContent)
-      .toBe("Edit Menu Item");
+    expect(document.getElementById("item-description").value).toBe("Nice");
+    expect(document.getElementById("item-price").value).toBe("50");
+    expect(document.getElementById("item-category").value).toBe("Fast Food");
+    expect(document.getElementById("item-calories").value).toBe("500");
+    expect(document.getElementById("item-protein").value).toBe("20");
+    expect(document.getElementById("item-carbs").value).toBe("45");
+    expect(document.querySelector(".item-allergen").checked).toBe(true);
+    expect(document.querySelector(".item-dietary").checked).toBe(true);
+    expect(document.getElementById("modal-title").textContent).toBe("Edit Menu Item");
   });
 
-  test("saveItem adds new item", async () => {
+  test("openEditItem returns if item is not found", async () => {
     getDocs.mockResolvedValue({ docs: [] });
+
+    await loadModule();
+
+    await window.views.openEditItem("missing");
+
+    expect(document.getElementById("item-edit-modal").classList.contains("hidden")).toBe(true);
+  });
+
+  test("saveItem adds new item with pending status and empty review reason", async () => {
+    await loadModule();
+
+    document.getElementById("edit-item-id").value = "";
+    document.getElementById("item-name").value = "Burger";
+    document.getElementById("item-description").value = "Tasty burger";
+    document.getElementById("item-price").value = "45";
+    document.getElementById("item-category").value = "Main Course";
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(addDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        vendorId: "user123",
+        vendorName: "Test Shop",
+        name: "Burger",
+        description: "Tasty burger",
+        price: 45,
+        category: "Main Course",
+        available: true,
+        status: "pending",
+        reviewReason: "",
+        createdAt: "timestamp"
+      })
+    );
+  });
+
+  test("saveItem updates existing item and sends it back to pending", async () => {
+    await loadModule();
+
+    document.getElementById("edit-item-id").value = "item123";
+    document.getElementById("item-name").value = "Updated Burger";
+    document.getElementById("item-description").value = "Updated description";
+    document.getElementById("item-price").value = "55";
+    document.getElementById("item-category").value = "Main Course";
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(updateDoc).toHaveBeenCalledWith(
+      "docRef",
+      expect.objectContaining({
+        vendorId: "user123",
+        vendorName: "Test Shop",
+        name: "Updated Burger",
+        description: "Updated description",
+        price: 55,
+        category: "Main Course",
+        available: true,
+        status: "pending",
+        reviewReason: "",
+        createdAt: "timestamp"
+      })
+    );
+  });
+
+  test("saveItem rejects negative price", async () => {
+    await loadModule();
+
+    document.getElementById("item-name").value = "Burger";
+    document.getElementById("item-description").value = "Nice";
+    document.getElementById("item-price").value = "-10";
+    document.getElementById("item-category").value = "Fast Food";
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(alert).toHaveBeenCalledWith("Price must be a positive amount greater than 0.");
+    expect(addDoc).not.toHaveBeenCalled();
+  });
+
+  test("saveItem rejects zero price", async () => {
+    await loadModule();
+
+    document.getElementById("item-name").value = "Burger";
+    document.getElementById("item-description").value = "Nice";
+    document.getElementById("item-price").value = "0";
+    document.getElementById("item-category").value = "Fast Food";
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(alert).toHaveBeenCalledWith("Price must be a positive amount greater than 0.");
+    expect(addDoc).not.toHaveBeenCalled();
+  });
+
+  test("saveItem rejects invalid image type", async () => {
+    await loadModule();
+
+    document.getElementById("item-name").value = "Burger";
+    document.getElementById("item-description").value = "Nice";
+    document.getElementById("item-price").value = "50";
+    document.getElementById("item-category").value = "Fast Food";
+
+    const badFile = new File(["fake"], "menu.gif", { type: "image/gif" });
+
+    Object.defineProperty(document.getElementById("item-image"), "files", {
+      value: [badFile],
+      configurable: true
+    });
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(alert).toHaveBeenCalledWith("Only PNG and JPEG images are allowed.");
+    expect(addDoc).not.toHaveBeenCalled();
+  });
+
+  test("saveItem rejects oversized image", async () => {
+    await loadModule();
+
+    document.getElementById("item-name").value = "Burger";
+    document.getElementById("item-description").value = "Nice";
+    document.getElementById("item-price").value = "50";
+    document.getElementById("item-category").value = "Fast Food";
+
+    const bigFile = new File(["fake"], "menu.png", { type: "image/png" });
+
+    Object.defineProperty(bigFile, "size", {
+      value: 6 * 1024 * 1024,
+      configurable: true
+    });
+
+    Object.defineProperty(document.getElementById("item-image"), "files", {
+      value: [bigFile],
+      configurable: true
+    });
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(alert).toHaveBeenCalledWith("Image must be smaller than 5MB.");
+    expect(addDoc).not.toHaveBeenCalled();
+  });
+
+  test("saveItem uploads valid png image", async () => {
+    uploadBytes.mockResolvedValue();
+    getDownloadURL.mockResolvedValue("https://example.com/item.png");
 
     await loadModule();
 
@@ -173,174 +396,79 @@ describe("menu.js", () => {
     document.getElementById("item-price").value = "50";
     document.getElementById("item-category").value = "Fast Food";
 
-    const event = { preventDefault: jest.fn() };
+    const goodFile = new File(["fake"], "menu.png", { type: "image/png" });
 
-    await window.vendorActions.saveItem(event);
+    Object.defineProperty(document.getElementById("item-image"), "files", {
+      value: [goodFile],
+      configurable: true
+    });
 
-    expect(addDoc).toHaveBeenCalled();
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(uploadBytes).toHaveBeenCalled();
+    expect(getDownloadURL).toHaveBeenCalled();
+    expect(addDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        image: "https://example.com/item.png"
+      })
+    );
   });
 
-  test("saveItem updates existing item", async () => {
-    getDocs.mockResolvedValue({ docs: [] });
+  test("saveItem logs error when saving fails", async () => {
+    addDoc.mockRejectedValueOnce(new Error("save failed"));
 
     await loadModule();
 
-    document.getElementById("edit-item-id").value = "123";
     document.getElementById("item-name").value = "Burger";
     document.getElementById("item-description").value = "Nice";
     document.getElementById("item-price").value = "50";
     document.getElementById("item-category").value = "Fast Food";
 
-    const event = { preventDefault: jest.fn() };
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
 
-    await window.vendorActions.saveItem(event);
+    expect(console.error).toHaveBeenCalledWith(
+      "Error saving item:",
+      expect.any(Error)
+    );
+  });
 
-    expect(updateDoc).toHaveBeenCalled();
+  test("saveItem returns when no current user exists", async () => {
+    auth.onAuthStateChanged.mockImplementation((callback) => {
+      callback(null);
+    });
+
+    await loadModule();
+
+    await window.vendorActions.saveItem({
+      preventDefault: jest.fn()
+    });
+
+    expect(console.error).toHaveBeenCalledWith("No user logged in");
+    expect(addDoc).not.toHaveBeenCalled();
   });
 
   test("Add button opens modal in add mode", async () => {
-    getDocs.mockResolvedValue({ docs: [] });
-
     await loadModule();
-    await new Promise(r => setTimeout(r, 100));
 
     document.getElementById("add-item-btn").click();
 
-    expect(document.getElementById("modal-title").textContent)
-      .toBe("Add Menu Item");
-
-    expect(document.getElementById("item-edit-modal")
-      .classList.contains("hidden")).toBe(false);
-  });
- test("redirects if no user", async () => {
-  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-
-  auth.onAuthStateChanged.mockImplementation(cb => cb(null));
-
-  await loadModule();
-
-  expect(logSpy).toHaveBeenCalledWith("No user is signed in.");
-
-  logSpy.mockRestore();
-}); 
-test("saveItem rejects negative price", async () => {
-  global.alert = jest.fn();
-  getDocs.mockResolvedValue({ docs: [] });
-
-  await loadModule();
-
-  document.getElementById("item-name").value = "Burger";
-  document.getElementById("item-description").value = "Nice";
-  document.getElementById("item-price").value = "-10";
-  document.getElementById("item-category").value = "Fast Food";
-
-  const event = { preventDefault: jest.fn() };
-
-  await window.vendorActions.saveItem(event);
-
-  expect(alert).toHaveBeenCalledWith("Price must be a positive amount greater than 0.");
-  expect(addDoc).not.toHaveBeenCalled();
-});
-
-test("saveItem rejects zero price", async () => {
-  global.alert = jest.fn();
-  getDocs.mockResolvedValue({ docs: [] });
-
-  await loadModule();
-
-  document.getElementById("item-name").value = "Burger";
-  document.getElementById("item-description").value = "Nice";
-  document.getElementById("item-price").value = "0";
-  document.getElementById("item-category").value = "Fast Food";
-
-  const event = { preventDefault: jest.fn() };
-
-  await window.vendorActions.saveItem(event);
-
-  expect(alert).toHaveBeenCalledWith("Price must be a positive amount greater than 0.");
-  expect(addDoc).not.toHaveBeenCalled();
-});
-
-test("saveItem rejects invalid image type", async () => {
-  global.alert = jest.fn();
-  getDocs.mockResolvedValue({ docs: [] });
-
-  await loadModule();
-
-  document.getElementById("item-name").value = "Burger";
-  document.getElementById("item-description").value = "Nice";
-  document.getElementById("item-price").value = "50";
-  document.getElementById("item-category").value = "Fast Food";
-
-  const badFile = new File(["fake"], "menu.gif", { type: "image/gif" });
-
-  Object.defineProperty(document.getElementById("item-image"), "files", {
-    value: [badFile],
-    configurable: true
+    expect(document.getElementById("modal-title").textContent).toBe("Add Menu Item");
+    expect(document.getElementById("edit-item-id").value).toBe("");
+    expect(document.getElementById("item-edit-modal").classList.contains("hidden")).toBe(false);
   });
 
-  const event = { preventDefault: jest.fn() };
+  test("logs message if no user", async () => {
+    auth.onAuthStateChanged.mockImplementation((callback) => {
+      callback(null);
+    });
 
-  await window.vendorActions.saveItem(event);
+    await loadModule();
 
-  expect(alert).toHaveBeenCalledWith("Only PNG and JPEG images are allowed.");
-  expect(addDoc).not.toHaveBeenCalled();
-});
-
-test("saveItem rejects oversized image", async () => {
-  global.alert = jest.fn();
-  getDocs.mockResolvedValue({ docs: [] });
-
-  await loadModule();
-
-  document.getElementById("item-name").value = "Burger";
-  document.getElementById("item-description").value = "Nice";
-  document.getElementById("item-price").value = "50";
-  document.getElementById("item-category").value = "Fast Food";
-
-  const bigFile = new File(["fake"], "menu.png", { type: "image/png" });
-  Object.defineProperty(bigFile, "size", {
-    value: 6 * 1024 * 1024,
-    configurable: true
+    expect(console.log).toHaveBeenCalledWith("No user is signed in.");
   });
-
-  Object.defineProperty(document.getElementById("item-image"), "files", {
-    value: [bigFile],
-    configurable: true
-  });
-
-  const event = { preventDefault: jest.fn() };
-
-  await window.vendorActions.saveItem(event);
-
-  expect(alert).toHaveBeenCalledWith("Image must be smaller than 5MB.");
-  expect(addDoc).not.toHaveBeenCalled();
-});
-test("saveItem uploads valid png image", async () => {
-  getDocs.mockResolvedValue({ docs: [] });
-  uploadBytes.mockResolvedValue();
-  getDownloadURL.mockResolvedValue("https://example.com/item.png");
-
-  await loadModule();
-
-  document.getElementById("item-name").value = "Burger";
-  document.getElementById("item-description").value = "Nice";
-  document.getElementById("item-price").value = "50";
-  document.getElementById("item-category").value = "Fast Food";
-
-  const goodFile = new File(["fake"], "menu.png", { type: "image/png" });
-
-  Object.defineProperty(document.getElementById("item-image"), "files", {
-    value: [goodFile],
-    configurable: true
-  });
-
-  const event = { preventDefault: jest.fn() };
-
-  await window.vendorActions.saveItem(event);
-
-  expect(uploadBytes).toHaveBeenCalled();
-  expect(getDownloadURL).toHaveBeenCalled();
-  expect(addDoc).toHaveBeenCalled();
-});
 });

--- a/admin-MenuManagement.html
+++ b/admin-MenuManagement.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>CampusBites - Admin Dashboard</title>
+    <title>CampusBites - Admin Menu Management</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
 </head>
@@ -12,24 +12,26 @@
                 <i data-lucide="utensils" class="w-8 h-8 text-indigo-600"></i>
                 <span class="text-xl font-bold text-gray-900">CampusBites</span>
             </header>
+
             <section class="md:flex space-x-8">
                 <a id="AdmindashboardLink" href="admin-dashboard.html" class="text-gray-700 hover:text-indigo-600">Dashboard</a>
                 <a href="vendor-management.html" class="text-gray-700 hover:text-indigo-600">Vendors</a>
+                <a href="admin-menuManagement.html" class="text-gray-700 hover:text-indigo-600">Menu Management</a>
                 <a href="admin-analytics.html" class="text-gray-700 hover:text-indigo-600">Analytics</a>
             </section>
+
             <section class="flex items-center gap-4">
-                <a href="login.html" id="loginLink"class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
+                <a href="login.html" id="loginLink" class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
                     Sign in
                 </a>
                 <button id="logoutBtn" class="bg-gray-200 text-gray-800 px-4 py-2 rounded-lg hover:bg-gray-300 transition hidden">
-                        Logout
+                    Logout
                 </button>
             </section>
-
         </section>
     </nav>
-    <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">    
-    <h2 class="text-2xl font-bold mb-6">Vendor Management</h2>
+    <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pt-24">
+    <h2 class="text-2xl font-bold mb-6">Menu Management</h2>
     
     <section class="bg-white rounded-xl shadow-sm overflow-hidden">
         
@@ -38,10 +40,10 @@
             <thead class="bg-gray-50">
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Location</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Menu Items</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Reviews</th>
                 </tr>
             </thead>
 
@@ -50,18 +52,13 @@
             </tbody>
 
         </table>
+        <section id="details-modal" class="hidden"></section>
 
     </section>
 
     </section>
-<script type="module" src="./scripts/admin.js"></script>
-<script type="module">
-  import { initAuthUI, logout } from "./scripts/auth.js";
-
-  initAuthUI();
-  lucide.createIcons();
-  // Attach logout button
-  document.getElementById("logoutBtn")?.addEventListener("click", logout);
-</script>
+    <script type="module" src="./scripts/admin-menuManagement.js">
+        import { initAuthUI, logout } from "./scripts/auth.js";
+    </script>
 </body>
 </html>

--- a/admin-analytics.html
+++ b/admin-analytics.html
@@ -18,6 +18,7 @@
             <section class="md:flex space-x-8">
                 <a id="AdmindashboardLink" href="admin-dashboard.html" class="text-gray-700 hover:text-indigo-600">Dashboard</a>
                 <a href="vendor-management.html" class="text-gray-700 hover:text-indigo-600">Vendors</a>
+                <a href="admin-menuManagement.html" class="text-gray-700 hover:text-indigo-600">Menu Management</a>
                 <a href="admin-analytics.html" class="text-gray-700 hover:text-indigo-600">Analytics</a>
             </section>
 

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -17,6 +17,7 @@
                 <a id="AdmindashboardLink" href="admin-dashboard.html" class="text-gray-700 hover:text-indigo-600">Dashboard</a>
                 <a href="vendor-management.html" class="text-gray-700 hover:text-indigo-600">Vendors</a>
                 <a href="admin-analytics.html" class="text-gray-700 hover:text-indigo-600">Analytics</a>
+                <a href="admin-menuManagement.html" class="text-gray-700 hover:text-indigo-600">Menu Management</a>
                 <a href="admin-payouts.html" class="text-gray-700 hover:text-indigo-600">Payouts</a>
             </section>
             <section class="flex items-center gap-4">

--- a/scripts/admin-menuManagement.js
+++ b/scripts/admin-menuManagement.js
@@ -325,7 +325,7 @@ async function loadMenuItems() {
 function logoutUser() {
   auth.signOut()
     .then(() => {
-      window.location.href = "login.html";
+      window.location.assign("login.html");
     })
     .catch((error) => {
       console.error("Logout failed:", error);
@@ -338,7 +338,7 @@ if (logoutBtn) {
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
-    window.location.href = "login.html";
+    window.location.assign("login.html");
     return;
   }
 
@@ -350,7 +350,7 @@ onAuthStateChanged(auth, async (user) => {
     const userSnap = await getDoc(userRef);
 
     if (!userSnap.exists()) {
-      window.location.href = "login.html";
+      window.location.assign("login.html");
       return;
     }
 
@@ -358,13 +358,13 @@ onAuthStateChanged(auth, async (user) => {
 
     if (currentUser.role !== "admin") {
       alert("Access denied. Admins only.");
-      window.location.href = "index.html";
+      window.location.assign("index.html");
       return;
     }
 
     loadMenuItems();
   } catch (error) {
     console.error("Error checking admin access:", error);
-    window.location.href = "login.html";
+    window.location.assign("login.html");
   }
 });

--- a/scripts/admin-menuManagement.js
+++ b/scripts/admin-menuManagement.js
@@ -1,0 +1,370 @@
+import {
+  auth,
+  db,
+  onAuthStateChanged,
+  getDoc,
+  getDocs,
+  updateDoc,
+  doc,
+  collection
+} from "./database.js";
+globalThis.lucide?.createIcons?.();
+let loadedMenuItems = [];
+const tbody = document.getElementById("vendor-table-body");
+const loginLink = document.getElementById("loginLink");
+const logoutBtn = document.getElementById("logoutBtn");
+
+function getStatusBadge(status) {
+  const classes = {
+    pending: "bg-yellow-100 text-yellow-800",
+    approved: "bg-green-100 text-green-800",
+    suspended: "bg-red-100 text-red-800"
+  };
+
+  return `
+    <span class="px-2 py-1 rounded-full text-xs font-semibold capitalize ${classes[status] || classes.pending}">
+      ${status || "pending"}
+    </span>
+  `;
+}
+
+async function getVendorName(vendorId) {
+  try {
+    const vendorRef = doc(db, "users", vendorId);
+    const vendorSnap = await getDoc(vendorRef);
+
+    if (vendorSnap.exists()) {
+      const vendor = vendorSnap.data();
+      return vendor.shopName || vendor.fullName || "Unknown Vendor";
+    }
+
+    return "Unknown Vendor";
+  } catch (error) {
+    console.error("Error loading vendor:", error);
+    return "Unknown Vendor";
+  }
+}
+
+async function approveMenuItem(itemId) {
+  try {
+    await updateDoc(doc(db, "menu_items", itemId), {
+      status: "approved",
+      reviewReason: ""
+    });
+
+    alert("Menu item approved successfully.");
+    loadMenuItems();
+  } catch (error) {
+    console.error("Error approving menu item:", error);
+    alert("Failed to approve menu item.");
+  }
+}
+
+async function suspendMenuItem(itemId) {
+  const reason = prompt("Enter the reason for suspending/rejecting this menu item:");
+
+  if (!reason || reason.trim() === "") {
+    alert("Suspension reason is required.");
+    return;
+  }
+
+  try {
+    await updateDoc(doc(db, "menu_items", itemId), {
+      status: "suspended",
+      reviewReason: reason.trim()
+    });
+
+    alert("Menu item suspended successfully.");
+    loadMenuItems();
+  } catch (error) {
+    console.error("Error suspending menu item:", error);
+    alert("Failed to suspend menu item.");
+  }
+}
+function showItemDetails(item) {
+  const modal = document.getElementById("details-modal");
+  if (!modal) return;
+
+
+  modal.innerHTML = `
+    <section class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center px-4">
+      <article class="bg-white rounded-2xl max-w-md w-full max-h-[90vh] overflow-y-auto relative shadow-xl">
+
+        <button id="closeDetailsModal"
+          class="absolute top-3 right-3 bg-white rounded-full p-1 shadow hover:bg-gray-100">
+          ✕
+        </button>
+
+        <img
+          src="${item.image || item.imageUrl || "assets/default_vendor.jpg"}"
+          alt="${item.name || "Menu item"}"
+          class="w-full h-52 object-cover rounded-t-2xl"
+        >
+
+        <section class="p-8">
+          <section class="flex justify-between items-start mb-2">
+            <section>
+              <p class="text-sm text-indigo-600 font-medium">${item.vendorName || "Vendor"}</p>
+              <h2 class="text-2xl font-bold text-gray-900">${item.name || "Unnamed Item"}</h2>
+            </section>
+
+            <section>
+              <p class="font-bold text-indigo-600">
+                R${Number(item.price || 0).toFixed(2)}
+              </p>
+            </section>
+          </section>
+
+          <p class="text-sm text-gray-600 mb-4">
+            ${item.description || "No description available."}
+          </p>
+
+          <section class="mb-4">
+            <h3 class="font-semibold text-sm mb-2 text-red-600">⚠ Allergens</h3>
+            ${
+              (item.allergens || []).length
+                ? `<section class="flex flex-wrap gap-2">
+                    ${(item.allergens || []).map(a => `
+                      <span class="text-xs bg-red-50 text-red-600 border border-red-200 px-3 py-1 rounded-full">
+                        ${a}
+                      </span>
+                    `).join("")}
+                  </section>`
+                : `<p class="text-sm text-gray-500">No allergens listed.</p>`
+            }
+          </section>
+
+          <section class="mb-4">
+            <h3 class="font-semibold text-sm mb-2 text-green-600">✓ Dietary Information</h3>
+            ${
+              (item.dietary || []).length
+                ? `<section class="flex flex-wrap gap-2">
+                    ${(item.dietary || []).map(tag => `
+                      <span class="text-xs bg-green-100 text-green-700 px-3 py-1 rounded-full">
+                        ${tag}
+                      </span>
+                    `).join("")}
+                  </section>`
+                : `<p class="text-sm text-gray-500">No dietary information listed.</p>`
+            }
+          </section>
+
+          <section class="mb-4">
+            <h3 class="font-semibold text-sm mb-2">Nutritional Info</h3>
+
+            <section class="grid grid-cols-3 gap-3 text-center">
+              <section class="bg-gray-50 rounded-lg p-3">
+                <p class="font-bold">${item.calories || 320}</p>
+                <p class="text-xs text-gray-500">kcal</p>
+              </section>
+
+              <section class="bg-gray-50 rounded-lg p-3">
+                <p class="font-bold">${item.protein || "18"}g</p>
+                <p class="text-xs text-gray-500">protein</p>
+              </section>
+
+              <section class="bg-gray-50 rounded-lg p-3">
+                <p class="font-bold">${item.carbs || "18"}g</p>
+                <p class="text-xs text-gray-500">carbs</p>
+              </section>
+            </section>
+          </section>
+
+          <section class="mt-4">
+            <h3 class="font-semibold text-sm mb-2">Admin Review</h3>
+            <p class="text-sm text-gray-600">
+              ${item.reviewReason || "No admin review yet."}
+            </p>
+          </section>
+        </section>
+      </article>
+    </section>
+  `;
+
+  modal.classList.remove("hidden");
+
+  document.getElementById("closeDetailsModal")?.addEventListener("click", () => {
+    modal.classList.add("hidden");
+    modal.innerHTML = "";
+  });
+globalThis.lucide?.createIcons?.();
+}
+
+async function loadMenuItems() {
+  if (!tbody) return;
+  loadedMenuItems = [];
+  tbody.innerHTML = `
+    <tr>
+      <td colspan="5" class="px-6 py-4 text-center text-gray-500">
+        Loading menu items...
+      </td>
+    </tr>
+  `;
+
+  try {
+    const snapshot = await getDocs(collection(db, "menu_items"));
+
+    if (snapshot.empty) {
+      tbody.innerHTML = `
+        <tr>
+          <td colspan="5" class="px-6 py-4 text-center text-gray-500">
+            No menu items found.
+          </td>
+        </tr>
+      `;
+      return;
+    }
+
+    const rows = await Promise.all(
+      snapshot.docs.map(async (itemDoc) => {
+        const item = itemDoc.data();
+        const itemId = itemDoc.id;
+
+        const vendorName = await getVendorName(item.vendorId);
+        const status = item.status || "pending";
+        const reviewReason = item.reviewReason || "No review yet.";
+        const fullItem = {
+        id: itemId,
+        ...item,
+        vendorName
+        };
+
+        loadedMenuItems.push(fullItem);
+
+        return `
+          <tr>
+            <td class="px-6 py-4 text-sm text-gray-700">
+              ${vendorName}
+            </td>
+
+            <td class="px-6 py-4">
+              <section class="flex items-center gap-3">
+                ${
+                  item.image
+                    ? `<img src="${item.image}" alt="${item.name}" class="w-12 h-12 rounded-lg object-cover">`
+                    : `<section class="w-12 h-12 rounded-lg bg-gray-100 flex items-center justify-center">
+                        <i data-lucide="image" class="w-5 h-5 text-gray-400"></i>
+                      </section>`
+                }
+
+                <section>
+                  <button 
+                    class="item-details-btn font-medium text-indigo-600 hover:underline text-left"
+                    data-id="${itemId}">
+                    ${item.name || "Unnamed Item"}
+                    </button>
+                  <p class="text-sm text-gray-500">R${item.price || 0}</p>
+                </section>
+              </section>
+            </td>
+
+            <td class="px-6 py-4">
+              ${getStatusBadge(status)}
+            </td>
+
+            <td class="px-6 py-4">
+              <section class="flex gap-2">
+                <button 
+                  class="approve-btn bg-green-600 text-white px-3 py-1 rounded-lg hover:bg-green-700 text-sm"
+                  data-id="${itemId}">
+                  Approve
+                </button>
+
+                <button 
+                  class="suspend-btn bg-red-600 text-white px-3 py-1 rounded-lg hover:bg-red-700 text-sm"
+                  data-id="${itemId}">
+                  Suspend
+                </button>
+              </section>
+            </td>
+
+            <td class="px-6 py-4 text-sm text-gray-600">
+              ${reviewReason}
+            </td>
+          </tr>
+        `;
+      })
+    );
+
+    tbody.innerHTML = rows.join("");
+    lucide.createIcons();
+    document.querySelectorAll(".item-details-btn").forEach((button) => {
+        button.addEventListener("click", () => {
+            const selectedItem = loadedMenuItems.find(item => item.id === button.dataset.id);
+
+            if (selectedItem) {
+            showItemDetails(selectedItem);
+            }
+        });
+    });
+
+    document.querySelectorAll(".approve-btn").forEach((button) => {
+      button.addEventListener("click", () => {
+        approveMenuItem(button.dataset.id);
+      });
+    });
+
+    document.querySelectorAll(".suspend-btn").forEach((button) => {
+      button.addEventListener("click", () => {
+        suspendMenuItem(button.dataset.id);
+      });
+    });
+  } catch (error) {
+    console.error("Error loading menu items:", error);
+
+    tbody.innerHTML = `
+      <tr>
+        <td colspan="5" class="px-6 py-4 text-center text-red-500">
+          Failed to load menu items.
+        </td>
+      </tr>
+    `;
+  }
+}
+
+function logoutUser() {
+  auth.signOut()
+    .then(() => {
+      window.location.href = "login.html";
+    })
+    .catch((error) => {
+      console.error("Logout failed:", error);
+    });
+}
+
+if (logoutBtn) {
+  logoutBtn.addEventListener("click", logoutUser);
+}
+
+onAuthStateChanged(auth, async (user) => {
+  if (!user) {
+    window.location.href = "login.html";
+    return;
+  }
+
+  if (loginLink) loginLink.classList.add("hidden");
+  if (logoutBtn) logoutBtn.classList.remove("hidden");
+
+  try {
+    const userRef = doc(db, "users", user.uid);
+    const userSnap = await getDoc(userRef);
+
+    if (!userSnap.exists()) {
+      window.location.href = "login.html";
+      return;
+    }
+
+    const currentUser = userSnap.data();
+
+    if (currentUser.role !== "admin") {
+      alert("Access denied. Admins only.");
+      window.location.href = "index.html";
+      return;
+    }
+
+    loadMenuItems();
+  } catch (error) {
+    console.error("Error checking admin access:", error);
+    window.location.href = "login.html";
+  }
+});

--- a/scripts/browse.js
+++ b/scripts/browse.js
@@ -346,7 +346,7 @@ const loadMenuItems = async () => {
     });
 
   const visibleItems = items
-  .filter(item => approvedVendorIds.has(item.vendorId))
+  .filter(item => approvedVendorIds.has(item.vendorId) && item.status === "approved")
   .map(item => {
     const vendor = vendorMap[item.vendorId];
 

--- a/scripts/menuManagement.js
+++ b/scripts/menuManagement.js
@@ -38,7 +38,19 @@ auth.onAuthStateChanged(async (user) => {
     }
   }
 });
+function getApprovalBadge(status = "pending") {
+  const classes = {
+    pending: "bg-yellow-100 text-yellow-800",
+    approved: "bg-green-100 text-green-800",
+    suspended: "bg-red-100 text-red-800"
+  };
 
+  return `
+    <span class="px-2 py-1 rounded-full text-xs font-semibold capitalize ${classes[status] || classes.pending}">
+      ${status}
+    </span>
+  `;
+}
 
 const views = {
 
@@ -62,10 +74,24 @@ initMenuManagement: async () => {
         </td> 
             <td class="px-6 py-4">${item.category}</td>
             <td class="px-6 py-4">R${item.price}</td>
-            <td class="px-6 py-4">
-                <span class="px-2 py-1 rounded-full text-xs ${item.available ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}">
-                    ${item.available ? 'Available' : 'Sold Out'}
-                </span>
+            <td class="px-6 py-4 space-y-2">
+                <section>
+                    ${getApprovalBadge(item.status || "pending")}
+                </section>
+
+                <section>
+                    <span class="px-2 py-1 rounded-full text-xs ${item.available ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}">
+                        ${item.available ? 'Available' : 'Sold Out'}
+                    </span>
+                </section>
+
+                ${
+                item.status === "suspended" && item.reviewReason
+                    ? `<p class="text-xs text-red-600 mt-2">
+                        Admin review: ${item.reviewReason}
+                    </p>`
+                    : ""
+                }
             </td>
             <td class="px-6 py-4">
                 <button onclick="views.openEditItem('${item.id}')">
@@ -204,6 +230,8 @@ saveItem: async (event) => {
         carbs,
         dietary,
         available: true,
+        status: "pending",
+        reviewReason: "",
         createdAt: serverTimestamp()
     };
     if (imageUrl) {


### PR DESCRIPTION
## Overview
This PR introduces a full **admin moderation workflow for menu items** to ensure only approved items appear on the platform.

---

## Key Changes

### Menu Item Moderation
- Added **status field** to menu items:
  - `pending`
  - `approved`
  - `suspended`
- Added **reviewReason** field for admin feedback

### Vendor Updates
- New and edited items now default to **pending**
- Vendors can:
  - View item status
  - See admin feedback when items are suspended
  - Toggle **availability (Sold Out / Restock)** without affecting approval status

### Admin Features
- Admin can:
  - Approve menu items → status = `approved`
  - Suspend/reject items → status = `suspended`
  - Provide a **review reason**
- Added **item details modal** for better inspection

### Browse Page Updates
- Only displays items that are:
  - From **approved vendors**
  - With status **approved**
  - And marked as **available**

### Firestore Rules
- Vendors:
  - Cannot self-approve items
  - Can only modify their own items
  - Can only toggle `available` without affecting moderation status
- Admin:
  - Has full control over `status` and `reviewReason`

---

## Impact
- Improves **content quality control**
- Prevents unapproved or inappropriate items from appearing
- Aligns menu moderation with existing **vendor approval system**

---

## Testing
Testing will be added and completed soon to cover:
- Admin approval and suspension flows  
- Vendor item creation and editing behavior  
- Browse page filtering logic  

---