### PR TITLE
Fix refund pending orders reverting to pending after page reload

### DIFF
--- a/scripts/checkOut.js
+++ b/scripts/checkOut.js
@@ -457,9 +457,19 @@ async function refundPaidOrder(order) {
       throw new Error(err.error || `Refund failed (${res.status})`);
     }
 
+    await updateDoc(doc(db, "orders", order.id), {
+      status: "refund pending",
+      refundStatus: "pending",
+      updatedAt: serverTimestamp()
+    });
+
     ordersCache = ordersCache.map((cachedOrder) =>
       cachedOrder.id === order.id
-        ? { ...cachedOrder, status: "refund pending" }
+        ? {
+            ...cachedOrder,
+            status: "refund pending",
+            refundStatus: "pending"
+          }
         : cachedOrder
     );
 
@@ -471,6 +481,7 @@ async function refundPaidOrder(order) {
     alert("Could not initiate refund: " + error.message);
   }
 }
+
 
 // ----------------------
 // Card click handler


### PR DESCRIPTION
## Overview

This PR fixes an issue where refunded orders reverted back to `Pending` after refreshing the orders page.

Previously, the refund flow only updated the order status locally in the UI after initiating a Paystack refund request. Since the updated status was not persisted to Firestore, reloading the page caused the order to appear as `Pending` again.

This also resulted in duplicate refund attempts being possible for the same order.

---
## Result

Orders now:
- remain in the `Refund Processing` section after refresh
- correctly persist refund state in Firestore
- no longer allow duplicate refund initiation