### PR TITLE
Fix current order filtering for previous collected orders

### DIFF
--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -35,6 +35,30 @@ export function formatTimestamp(timestamp) {
   });
 }
 
+<<<<<<< Updated upstream
+=======
+export function isOrderFromToday(order) {
+  if (!order.createdAt?.toDate) return false;
+
+  const orderDate = order.createdAt.toDate();
+  const today = new Date();
+
+  return (
+    orderDate.getFullYear() === today.getFullYear() &&
+    orderDate.getMonth() === today.getMonth() &&
+    orderDate.getDate() === today.getDate()
+  );
+}
+
+export function getDateKey(timestamp) {
+  if (!timestamp?.toDate) return "unknown-date";
+
+  const date = timestamp.toDate();
+
+  return date.toISOString().slice(0, 10);
+}
+
+>>>>>>> Stashed changes
 export function normaliseStatus(status) {
   return String(status || "Pending").trim().toLowerCase();
 }
@@ -142,10 +166,20 @@ export async function renderOrdersByStatus(orders) {
 
   const enrichedOrders = await enrichOrdersWithCustomerNames(orders);
 
+<<<<<<< Updated upstream
   const pendingOrders = enrichedOrders.filter((order) => formatStatus(order.status) === "Pending");
   const preparingOrders = enrichedOrders.filter((order) => formatStatus(order.status) === "Preparing");
   const readyOrders = enrichedOrders.filter((order) => formatStatus(order.status) === "Ready");
   const collectedOrders = enrichedOrders.filter((order) => formatStatus(order.status) === "Collected");
+=======
+  const pendingOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Pending");
+  const preparingOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Preparing");
+  const readyOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Ready");
+
+  const collectedOrders = numberedOrders.filter((order) => {
+    return formatStatus(order.status) === "Collected" && isOrderFromToday(order);
+  });
+>>>>>>> Stashed changes
 
   pendingContainer.innerHTML = pendingOrders.length
     ? pendingOrders.map((order, index) => buildOrderHTML(order, index)).join("")
@@ -213,6 +247,41 @@ export function attachDragAndDropListeners() {
   });
 }
 
+<<<<<<< Updated upstream
+=======
+if (typeof document !== "undefined" && !document.body?.dataset.markPaidListenerAttached) {
+  document.body?.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".mark-paid-btn");
+    if (!btn) return;
+
+    const orderId = btn.dataset.markPaidId;
+    if (!orderId) return;
+
+    btn.disabled = true;
+    btn.textContent = "Marking as paid...";
+
+    try {
+      const snap = await getDoc(doc(db, "orders", orderId));
+      if (!snap.exists()) {
+        alert("Order no longer exists.");
+        return;
+      }
+
+      await markCashOrderAsPaid({ id: orderId, ...snap.data() });
+    } catch (err) {
+      console.error("Failed to mark order as paid:", err);
+      alert("Failed to mark order as paid.");
+      btn.disabled = false;
+      btn.textContent = "Mark as Paid";
+    }
+  });
+
+  if (document.body) {
+    document.body.dataset.markPaidListenerAttached = "true";
+  }
+}
+
+>>>>>>> Stashed changes
 export function listenToVendorOrders(vendorId, callback) {
   const q = query(
     collection(db, "orders"),

--- a/scripts/vendor-dashboard.js
+++ b/scripts/vendor-dashboard.js
@@ -100,18 +100,47 @@ export async function fetchVendorOrders(vendorId) {
   return orders;
 }
 
+
+export function isOrderFromToday(order) {
+  if (!order.createdAt?.toDate) return false;
+
+  const orderDate = order.createdAt.toDate();
+  const today = new Date();
+
+  return (
+    orderDate.getFullYear() === today.getFullYear() &&
+    orderDate.getMonth() === today.getMonth() &&
+    orderDate.getDate() === today.getDate()
+  );
+}
+
 export function renderQuickStats(orders) {
   const pendingCount = document.getElementById("pending-count");
   const preparingCount = document.getElementById("preparing-count");
   const readyCount = document.getElementById("ready-count");
   const collectedCount = document.getElementById("collected-count");
 
-  if (!pendingCount || !preparingCount || !readyCount || !collectedCount) return;
+  if (!pendingCount || !preparingCount || !readyCount || !collectedCount) {
+    return;
+  }
 
-  pendingCount.textContent = orders.filter((order) => formatStatus(order.status) === "Pending").length;
-  preparingCount.textContent = orders.filter((order) => formatStatus(order.status) === "Preparing").length;
-  readyCount.textContent = orders.filter((order) => formatStatus(order.status) === "Ready").length;
-  collectedCount.textContent = orders.filter((order) => formatStatus(order.status) === "Collected").length;
+  const todaysOrders = orders.filter(isOrderFromToday);
+
+  pendingCount.textContent = todaysOrders.filter(
+    (order) => formatStatus(order.status) === "Pending"
+  ).length;
+
+  preparingCount.textContent = todaysOrders.filter(
+    (order) => formatStatus(order.status) === "Preparing"
+  ).length;
+
+  readyCount.textContent = todaysOrders.filter(
+    (order) => formatStatus(order.status) === "Ready"
+  ).length;
+
+  collectedCount.textContent = todaysOrders.filter(
+    (order) => formatStatus(order.status) === "Collected"
+  ).length;
 }
 
 export function getStatusButtons(order) {


### PR DESCRIPTION
### Overview

This PR refines the vendor order management workflow by improving how current and historical orders are displayed across the platform.

### Changes Made
Fixed an issue where collected orders from previous days continued appearing in the live Order Management board.
Added date-based filtering so only orders created on the current day appear in the active workflow view.
Preserved historical order data in Firebase for analytics, revenue tracking, and reporting purposes.
Improved consistency between Vendor Dashboard quick stats and the Order Management board.
Added helper logic for determining whether an order belongs to the current day.
Maintained existing drag-and-drop workflow functionality and payment handling logic.