### PR TITLE
Fix vendor order filtering for daily orders

### DIFF
--- a/__tests__/orders.test.js
+++ b/__tests__/orders.test.js
@@ -227,49 +227,56 @@ describe("orders.js", () => {
   });
 
   test("renders collected orders into completedOrders", async () => {
-    db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "vendor-1" }));
+  db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "vendor-1" }));
 
-    const fakeDate = new Date("2026-05-08T10:00:00");
+  const today = new Date();
 
-    // Call 1: vendor profile
-    // Call 2: customer name → David King
-    db.getDoc
-      .mockResolvedValueOnce({
-        exists: () => true,
-        data: () => ({ role: "vendor" })
-      })
-      .mockResolvedValueOnce({
-        exists: () => true,
-        data: () => ({ fullName: "David King" })
-      });
-
-    db.onSnapshot.mockImplementation((_q, cb) => {
-      cb({
-        docs: [
-          {
-            id: "order-1",
-            data: () => ({
-              vendorId: "vendor-1",
-              userId: "customer-1",
-              status: "Collected",
-              createdAt: { seconds: 1, toDate: () => fakeDate },
-              menuItems: [{ name: "Wrap", quantity: 1 }]
-            })
-          }
-        ]
-      });
-      return jest.fn();
+  // Call 1: vendor profile
+  // Call 2: customer name → David King
+  db.getDoc
+    .mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ role: "vendor" })
+    })
+    .mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ fullName: "David King" })
     });
 
-    jest.isolateModules(() => {
-      require("../scripts/orders.js");
+  db.onSnapshot.mockImplementation((_q, cb) => {
+    cb({
+      docs: [
+        {
+          id: "order-1",
+          data: () => ({
+            vendorId: "vendor-1",
+            userId: "customer-1",
+            status: "Collected",
+            createdAt: {
+              seconds: Math.floor(today.getTime() / 1000),
+              toDate: () => today
+            },
+            updatedAt: {
+              toDate: () => today
+            },
+            menuItems: [{ name: "Wrap", quantity: 1 }]
+          })
+        }
+      ]
     });
 
-    await flush();
-
-    expect(document.getElementById("completedOrders").innerHTML).toContain("David King");
-    expect(document.getElementById("completedOrders").innerHTML).toContain("Collected");
+    return jest.fn();
   });
+
+  jest.isolateModules(() => {
+    require("../scripts/orders.js");
+  });
+
+  await flush();
+
+  expect(document.getElementById("completedOrders").innerHTML).toContain("David King");
+  expect(document.getElementById("completedOrders").innerHTML).toContain("Collected");
+});
 
   test("shows fallback text when there are no orders", async () => {
     db.onAuthStateChanged.mockImplementation((_auth, cb) => cb({ uid: "vendor-1" }));

--- a/__tests__/orders.test.js
+++ b/__tests__/orders.test.js
@@ -1013,4 +1013,64 @@ test("mark-paid click does nothing when button has no order id", async () => {
   expect(db.updateDoc).not.toHaveBeenCalled();
   expect(db.addDoc).not.toHaveBeenCalled();
 });
+test("shouldShowTodayOrder returns true when order has no Firestore timestamp", () => {
+  jest.isolateModules(() => {
+    const { shouldShowTodayOrder } = require("../scripts/orders.js");
+
+    expect(shouldShowTodayOrder({})).toBe(true);
+    expect(shouldShowTodayOrder({ createdAt: null })).toBe(true);
+    expect(shouldShowTodayOrder({ createdAt: {} })).toBe(true);
+  });
+});
+test("shouldShowTodayOrder returns true when order has no createdAt timestamp", () => {
+  jest.isolateModules(() => {
+    const { shouldShowTodayOrder } = require("../scripts/orders.js");
+
+    expect(shouldShowTodayOrder({})).toBe(true);
+    expect(shouldShowTodayOrder({ createdAt: null })).toBe(true);
+    expect(shouldShowTodayOrder({ createdAt: {} })).toBe(true);
+  });
+});
+test("dragstart stores order data in dataTransfer", () => {
+  jest.isolateModules(() => {
+    const { attachDragAndDropListeners } = require("../scripts/orders.js");
+
+    document.body.innerHTML = `
+      <section id="newOrders">
+        <article
+          draggable="true"
+          data-order-id="order-1"
+          data-order-status="Pending"
+          data-payment-method="cash"
+          data-payment-status="paid"
+        >
+          Order 1
+        </article>
+      </section>
+      <section id="preparingOrders"></section>
+      <section id="readyOrders"></section>
+      <section id="completedOrders"></section>
+    `;
+
+    attachDragAndDropListeners();
+
+    const article = document.querySelector("article");
+
+    const event = new Event("dragstart", {
+      bubbles: true
+    });
+
+    event.dataTransfer = {
+      setData: jest.fn()
+    };
+
+    article.dispatchEvent(event);
+
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith("orderId", "order-1");
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith("orderStatus", "Pending");
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith("paymentMethod", "cash");
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith("paymentStatus", "paid");
+  });
+});
+
 });

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -50,6 +50,15 @@ export function isOrderFromToday(order) {
   );
 }
 
+
+export function shouldShowTodayOrder(order) {
+  if (!order.createdAt?.toDate) {
+    return true;
+  }
+
+  return isOrderFromToday(order);
+}
+
 export function getDateKey(timestamp) {
   if (!timestamp?.toDate) return "unknown-date";
 
@@ -243,9 +252,12 @@ export async function renderOrdersByStatus(orders) {
   const numberedOrders = addDailyOrderNumbers(enrichedOrders);
 
   const pendingOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Pending");
-  const preparingOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Preparing");
-  const readyOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Ready");
-  const collectedOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Collected");
+const preparingOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Preparing");
+const readyOrders = numberedOrders.filter((order) => formatStatus(order.status) === "Ready");
+
+const collectedOrders = numberedOrders.filter((order) => {
+  return formatStatus(order.status) === "Collected" && shouldShowTodayOrder(order);
+});
 
   pendingContainer.innerHTML = pendingOrders.length
     ? pendingOrders.map((order) => buildOrderHTML(order)).join("")

--- a/scripts/vendor-dashboard.js
+++ b/scripts/vendor-dashboard.js
@@ -140,6 +140,14 @@ export function isOrderFromToday(order) {
   );
 }
 
+export function shouldShowTodayOrder(order) {
+  if (!order.createdAt?.toDate) {
+    return true;
+  }
+
+  return isOrderFromToday(order);
+}
+
 export function renderQuickStats(orders) {
   const pendingCount = document.getElementById("pending-count");
   const preparingCount = document.getElementById("preparing-count");
@@ -150,13 +158,7 @@ export function renderQuickStats(orders) {
     return;
   }
 
-const todaysOrders = orders.filter((order) => {
-  if (!order.createdAt) {
-    return true;
-  }
-
-  return isOrderFromToday(order);
-});
+const todaysOrders = orders.filter(shouldShowTodayOrder);
 
   pendingCount.textContent = todaysOrders.filter(
     (order) => formatStatus(order.status) === "Pending"
@@ -227,8 +229,8 @@ export function renderOrders(orders) {
   if (!ordersList) return;
 
   const currentOrders = orders.filter((order) => {
-    return formatStatus(order.status) !== "Collected";
-  });
+  return formatStatus(order.status) !== "Collected" && shouldShowTodayOrder(order);
+});
 
   if (!currentOrders.length) {
     ordersList.innerHTML = `<p class="text-gray-500">No current orders available.</p>`;


### PR DESCRIPTION
## Summary

This PR fixes the vendor order filtering issue where old orders were still appearing on the vendor dashboard/order views instead of only showing the relevant daily orders.

## Changes Made

- Added a helper function to check whether an order should be shown for the current day.
- Updated vendor dashboard filtering so old non-collected orders do not keep appearing on new days.
- Updated collected order filtering so the completed orders section only shows relevant daily collected orders.
- Updated the related Jest test so the collected order mock uses today’s date.
- Kept the existing vendor dashboard functionality intact, including:
  - cash/card payment badges
  - Mark as Paid flow
  - wallet ledger update for cash payments
  - status update workflow
  - collected order handling

## Why This Was Needed

The dashboard was showing old orders because some filters only checked the order status and did not check whether the order was created today. This caused previous-day orders to remain visible.

## Testing

Ran the Jest test suite with coverage.

```bash
npm test -- --coverage